### PR TITLE
chore(ci): Minor refactor to release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,8 @@ jobs:
 
       - name: Run unit tests
         run: yarn test
-        
+
   scan:
     needs: lint_and_test
     if: github.event_name == 'pull_request'
     uses: circlefin/circle-public-github-workflows/.github/workflows/pr-scan.yaml@v1
-
-  release_sbom:
-    needs: lint_and_test
-    if: github.event_name == 'push'
-    uses: circlefin/circle-public-github-workflows/.github/workflows/attach-release-assets.yaml@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,26 @@
-name: Tag Release
+name: PR Lint and Release
 
 on:
+  pull_request:
+    branches: [master]
   push:
     branches: [master]
 
 jobs:
-  release:
+  pr_lint_and_release:
     uses: circlefin/circle-public-github-workflows/.github/workflows/conventional-commit-release.yaml@v1
+    if: github.repository_owner == 'circlefin'
     with:
       release_type: node
+      lint_commits: false
     secrets:
       RELEASE_TOKEN: ${{ secrets.PUBLIC_RELEASES_TOKEN }}
       RELEASE_ACTOR_GPG_PRIVATE_KEY: ${{ secrets.PUBLIC_RELEASES_GPG_PRIVATE_KEY }}
       RELEASE_ACTOR_GPG_PASSPHRASE: ${{ secrets.PUBLIC_RELEASES_GPG_PASSPHRASE }}
+
+  release_sbom:
+    needs: pr_lint_and_release
+    if: github.event_name == 'push' && needs.pr_lint_and_release.outputs.release_created == 'true'
+    uses: circlefin/circle-public-github-workflows/.github/workflows/attach-release-assets.yaml@v1
+    with:
+      release_tag: ${{ needs.pr_lint_and_release.outputs.release_tag }}


### PR DESCRIPTION
## Summary

This is a minor refactor to the release workflow to address releases being created by both the attach assets and release-please workflows

## Detail
### Changeset

* `release_sbom` moved to `release.yaml` and configured to only attach SBOM to releases created by release-please.
* `release` renamed to `pr_lint_and_release` and will now run on `pull_request` events in order to lint Pull Request titles to ensure they conform to the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
* The `pr_lint_and_release` workflow will only run on PR and Pushes to the `master` branch on the upstream (`circlefin`) repository.

### Checklist
- [ ] Did you add new tests and confirm all tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `docs` folder)
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [ ] Did you run lint (`yarn lint`) and fix any issues?
- [ ] Did you run formatter (`yarn format:check`) and fix any issues (`yarn format:write`)?

## Testing
Mandatory section.
For each changeset, please highlight the tests you've added.

## Documentation
Optional section.
Link to the doc.
