### PR TITLE
fix!: Revert unaudited token receiver changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "rm -rf cache artifacts typechain-types",
     "build": "forge build",
-    "lint": "solhint -w 130 -c .solhint-src.json './src/**/*.sol' && solhint -w 245 -c .solhint-test.json './test/**/*.sol'",
+    "lint": "solhint -w 140 -c .solhint-src.json './src/**/*.sol' && solhint -w 290 -c .solhint-test.json './test/**/*.sol'",
     "test": "forge test -vv",
     "gasreport": "forge test --gas-report > gas/reports/gas-report.txt",
     "coverage": "forge coverage --ir-minimum",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "rm -rf cache artifacts typechain-types",
     "build": "forge build",
-    "lint": "solhint -w 140 -c .solhint-src.json './src/**/*.sol' && solhint -w 290 -c .solhint-test.json './test/**/*.sol'",
+    "lint": "solhint -w 130 -c .solhint-src.json './src/**/*.sol' && solhint -w 245 -c .solhint-test.json './test/**/*.sol'",
     "test": "forge test -vv",
     "gasreport": "forge test --gas-report > gas/reports/gas-report.txt",
     "coverage": "forge coverage --ir-minimum",

--- a/src/msca/6900/v0.7/account/UpgradableMSCA.sol
+++ b/src/msca/6900/v0.7/account/UpgradableMSCA.sol
@@ -18,7 +18,6 @@
  */
 pragma solidity 0.8.24;
 
-import {DefaultCallbackHandler} from "../../../../callback/DefaultCallbackHandler.sol";
 import {ExecutionUtils} from "../../../../utils/ExecutionUtils.sol";
 import {InvalidInitializationInput} from "../../shared/common/Errors.sol";
 import {FunctionReference} from "../common/Structs.sol";
@@ -27,17 +26,13 @@ import {BaseMSCA} from "./BaseMSCA.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
-import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
-import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-
 /**
  * @dev Leverage {ERC1967Proxy} brought by UUPS proxies, when this contract is set as the implementation behind such a
  * proxy.
  * The {_authorizeUpgrade} function is overridden here so more granular ACLs to the upgrade mechanism should be enforced
  * by plugins.
  */
-contract UpgradableMSCA is BaseMSCA, DefaultCallbackHandler, UUPSUpgradeable {
+contract UpgradableMSCA is BaseMSCA, UUPSUpgradeable {
     using ExecutionUtils for address;
 
     event UpgradableMSCAInitialized(address indexed account, address indexed entryPointAddress);
@@ -75,17 +70,6 @@ contract UpgradableMSCA is BaseMSCA, DefaultCallbackHandler, UUPSUpgradeable {
             emit PluginInstalled(plugins[i], manifestHashes[i], dependencies);
         }
         emit UpgradableMSCAInitialized(address(this), address(entryPoint));
-    }
-
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        override(BaseMSCA, DefaultCallbackHandler)
-        returns (bool)
-    {
-        // BaseMSCA has already implemented ERC165
-        return BaseMSCA.supportsInterface(interfaceId) || interfaceId == type(IERC721Receiver).interfaceId
-            || interfaceId == type(IERC1155Receiver).interfaceId || interfaceId == type(IERC1271).interfaceId;
     }
 
     /// @inheritdoc UUPSUpgradeable

--- a/src/msca/6900/v0.7/libs/SelectorRegistryLib.sol
+++ b/src/msca/6900/v0.7/libs/SelectorRegistryLib.sol
@@ -28,9 +28,6 @@ import {IAggregator} from "@account-abstraction/contracts/interfaces/IAggregator
 import {IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-import {IERC777Recipient} from "@openzeppelin/contracts/interfaces/IERC777Recipient.sol";
-import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
-import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 library SelectorRegistryLib {
@@ -64,10 +61,7 @@ library SelectorRegistryLib {
             || selector == IAccountLoupe.getInstalledPlugins.selector || selector == VALIDATE_USER_OP
             || selector == GET_ENTRYPOINT || selector == GET_NONCE || selector == INITIALIZE_UPGRADABLE_MSCA
             || selector == INITIALIZE_SINGLE_OWNER_MSCA || selector == TRANSFER_NATIVE_OWNERSHIP
-            || selector == RENOUNCE_NATIVE_OWNERSHIP || selector == GET_NATIVE_OWNER
-            || selector == IERC1155Receiver.onERC1155Received.selector
-            || selector == IERC1155Receiver.onERC1155BatchReceived.selector
-            || selector == IERC721Receiver.onERC721Received.selector || selector == IERC777Recipient.tokensReceived.selector;
+            || selector == RENOUNCE_NATIVE_OWNERSHIP || selector == GET_NATIVE_OWNER;
     }
 
     function _isErc4337FunctionSelector(bytes4 selector) internal pure returns (bool) {


### PR DESCRIPTION
## Summary

Revert unaudited changes changes related to NFT token receivers. These changes will be added back on the next audited contracts deployment / release. All affected contracts will be redeployed so as to only contain changes that were approved in the audit.

### Checklist
- [x] Did you add new tests and confirm all tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `docs` folder)
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint`) and fix any issues?
- [x] Did you run formatter (`yarn format:check`) and fix any issues (`yarn format:write`)?

## Testing

Added back delete tests related to token receivers.
