### PR TITLE
ci: add new ep v0.6 branch to github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, entry-point-v0.6]
 
 jobs:
   lint_and_test:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: Coverage
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, entry-point-v0.6]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,9 +2,9 @@ name: PR Lint and Release
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, entry-point-v0.6]
   push:
-    branches: [master]
+    branches: [master, entry-point-v0.6]
 
 jobs:
   pr_lint_and_release:


### PR DESCRIPTION
## Summary
We didn't update github workflow files when we added this branch. This PR is going to fix that on [entry-point-v0.6](https://github.com/circlefin/buidl-wallet-contracts/tree/entry-point-v0.6).

## Detail
### Changeset
* added `entry-point-v0.6` to ci, coverage and release flows

### Checklist
- [ ] Did you add new tests and confirm all tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `docs` folder)
- [ ] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint`) and fix any issues?
- [x] Did you run formatter (`yarn format:check`) and fix any issues (`yarn format:write`)?

## Testing
* No tests impacted

## Documentation
n/a
