### PR TITLE
docs: update Smart_Contract_Signatures_Encoding.md

### DIFF
--- a/docs/Smart_Contract_Signatures_Encoding.md
+++ b/docs/Smart_Contract_Signatures_Encoding.md
@@ -15,7 +15,7 @@ Contract signature (EIP-1271).
 
 ### Constant part
 
-{32-bytes signature verifier} -  padded address of the contract that implements the EIP-1271 interface to verify the signature
+{32-bytes signature verifier} -  zero-padded address of the contract that implements the EIP-1271 interface to verify the signature
 
 {32-bytes data position} - position of the start of the signature data (offset relative to the beginning of the signature data)
 


### PR DESCRIPTION
<img width="974" alt="Снимок экрана 2024-10-27 в 12 48 37" src="https://github.com/user-attachments/assets/b8ec033f-5dba-4000-ba3b-b2c1bcd61496">

To be more precise, replace "_padded_" with "**zero-padded**" to specify that the address is padded with zeros.