### PR TITLE
docs: Add verification instructions for proxy accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ For running integration tests in Anvil node, run `make anvil-tests`. This runs t
             
             Tip: if your contract's constructor arguments have complicated types, you can get this value instead by `console.log`ing the output of `abi.encode(arg1, arg2, ...)` in Solidity.
 
+          * For account factory contracts, you may also need to manually verify the proxy contract. To do this, you will first need to create an account using the account factory, and follow the above strategy. After verifying one account, all subsequent proxies should be automatically detected.
+
+            Tip: analyze the account creation function on the factory (e.g. `createAccount` for `SingleOwnerMSCAFactory`) to deduce the constructor arguments for the proxy deployment when trying to verify it on a block explorer.
+
          * Click verify and publish
 
 ### Deployment Metadata


### PR DESCRIPTION
## Summary

Add instructions for how to verify proxy account contracts created from account factories. Concrete example of this verification can be found at https://github.com/circlefin/buidl-wallet-contracts/pull/37.

