### PR TITLE
build: test out new dependency review action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,5 @@ jobs:
         run: yarn test
 
   scan:
-    needs: lint_and_test
     if: github.event_name == 'pull_request'
     uses: circlefin/circle-public-github-workflows/.github/workflows/pr-scan.yaml@v1

--- a/.licenseignore
+++ b/.licenseignore
@@ -1,2 +1,3 @@
 # GPL-3.0
+pkg:npm/%40erc6900/reference-implementation
 pkg:github/erc6900/reference-implementation

--- a/.licenseignore
+++ b/.licenseignore
@@ -1,2 +1,2 @@
 # GPL-3.0
-pkg:npm/erc6900-reference-implementation
+pkg:github/erc6900/reference-implementation

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "fcl": "github:rdubois-crypto/FreshCryptoLib#8179e08cac72072bd260796633fec41fdfd5b441",
     "forge-std": "github:foundry-rs/forge-std#v1.9.2",
     "solady": "0.0.243",
-    "erc6900-reference-implementation": "0.8.0-rc.6"
+    "@erc6900/reference-implementation": "github:erc6900/reference-implementation#v0.8.0-rc.6"
   },
   "devDependencies": {
     "solhint": "^5.0.3"

--- a/remappings.txt
+++ b/remappings.txt
@@ -5,5 +5,5 @@
 @solady/=node_modules/solady/src/
 @fcl/=node_modules/fcl/solidity/src/
 forge-std/=node_modules/forge-std/
-@erc6900/reference-implementation/=node_modules/erc6900-reference-implementation/src/
+@erc6900/reference-implementation/=node_modules/@erc6900/reference-implementation/src/
 @eth-infinitism/account-abstraction/=lib/account-abstraction/contracts/

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,10 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
+"@erc6900/reference-implementation@github:erc6900/reference-implementation#v0.8.0-rc.6":
+  version "0.8.0-rc.5"
+  resolved "https://codeload.github.com/erc6900/reference-implementation/tar.gz/6cdcfa653eb019d27d23586a86ff8171201a4066"
+
 "@modular-account-libs@github:erc6900/modular-account-libs#v0.8.0-rc.0":
   version "0.8.0-rc.0"
   resolved "https://codeload.github.com/erc6900/modular-account-libs/tar.gz/d64adb5bd100d6ad64d0a83b5dc13b356423d852"
@@ -261,11 +265,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-erc6900-reference-implementation@0.8.0-rc.6:
-  version "0.8.0-rc.6"
-  resolved "https://registry.yarnpkg.com/erc6900-reference-implementation/-/erc6900-reference-implementation-0.8.0-rc.6.tgz#57b91eefe9b1f9db05f2508efb452ec36388da41"
-  integrity sha512-Wc/lG0WosOMxZX+iZSGBfN9KQ5SLuyjooPc8e1BljLuDDDn9yViOEB+szHAoy2AQswwo6xJ3cvDEo035hCndJg==
 
 error-ex@^1.3.1:
   version "1.3.2"


### PR DESCRIPTION
## Summary
Test out the new [public dependency review action](https://github.com/circlefin/dependency-review-action/pull/1). We actually want to revert back to github package as node release is not maintained by any teams now. There're also discussions related to getting the org scope (`@erc6900`) back. So I think we should stick with github package for the time being.

## Detail
### Changeset
* revert back to github package
* ignore license check from 6900 reference impl as we discussed with legal
* remove `needs: lint_and_test` to speed up the build

### Checklist
- [ ] Did you add new tests and confirm all tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `docs` folder)
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint`) and fix any issues?
- [x] Did you run formatter (`yarn format:check`) and fix any issues (`yarn format:write`)?

## Testing
No features have been added, so just existing tests.

## Documentation
n/a
