### PR TITLE
fix: linting warnings and initializer logic

### DIFF
--- a/.solhint-src.json
+++ b/.solhint-src.json
@@ -1,6 +1,7 @@
 {
   "extends": "solhint:recommended",
   "rules": {
-    "compiler-version": ["error", "0.8.24"]
+    "compiler-version": ["error", "0.8.24"],
+    "func-visibility": ["error", { "ignoreConstructors": true }]
   }
 }

--- a/.solhint-test.json
+++ b/.solhint-test.json
@@ -4,6 +4,7 @@
     "compiler-version": ["error", "0.8.24"],
     "no-unused-vars": "off",
     "no-console": "off",
-    "func-name-mixedcase": "off"
+    "func-name-mixedcase": "off",
+    "func-visibility": ["error", { "ignoreConstructors": true }]
   }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@ fs_permissions = [{ access = "read-write", path = "./gas"},
     { access = "read", path = "./test/fixtures"}]
 src = 'src'
 out = 'out'
-libs = ['lib']
+libs = ['lib', 'node_modules']
 solc_version = "0.8.24"
 test = 'test'
 via_ir = true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "rm -rf cache artifacts typechain-types",
     "build": "forge build",
-    "lint": "solhint -w 103 -c .solhint-src.json './src/**/*.sol' && solhint -w 241 -c .solhint-test.json './test/**/*.sol' && solhint -w 0 -c .solhint-script.json './script/**/*.sol'",
+    "lint": "solhint -w 0 -c .solhint-src.json './src/**/*.sol' && solhint -w 0 -c .solhint-test.json './test/**/*.sol' && solhint -w 0 -c .solhint-script.json './script/**/*.sol'",
     "test": "forge test -vv",
     "gasreport": "forge test --gas-report > gas/reports/gas-report.txt",
     "coverage": "forge coverage --ir-minimum",

--- a/script/002_DeployUpgradableMSCAFactory.s.sol
+++ b/script/002_DeployUpgradableMSCAFactory.s.sol
@@ -42,7 +42,7 @@ contract DeployUpgradableMSCAFactoryScript is Script {
             factory = UpgradableMSCAFactory(EXPECTED_FACTORY_ADDRESS);
             console.log("Found existing factory at expected address: %s", address(factory));
         }
-        console.log("Account implementation address: %s", address(factory.accountImplementation()));
+        console.log("Account implementation address: %s", address(factory.ACCOUNT_IMPLEMENTATION()));
         vm.stopBroadcast();
     }
 }

--- a/script/003_DeploySingleOwnerMSCAFactory.s.sol
+++ b/script/003_DeploySingleOwnerMSCAFactory.s.sol
@@ -38,7 +38,7 @@ contract DeploySingleOwnerMSCAFactoryScript is Script {
             factory = SingleOwnerMSCAFactory(EXPECTED_FACTORY_ADDRESS);
             console.log("Found existing single owner MSCA factory at expected address: %s", address(factory));
         }
-        console.log("Account implementation address: %s", address(factory.accountImplementation()));
+        console.log("Account implementation address: %s", address(factory.ACCOUNT_IMPLEMENTATION()));
         vm.stopBroadcast();
     }
 }

--- a/script/005_DeployECDSAAccountFactory.s.sol
+++ b/script/005_DeployECDSAAccountFactory.s.sol
@@ -40,7 +40,7 @@ contract DeployECDSAAccountFactoryScript is Script {
             factory = ECDSAAccountFactory(EXPECTED_FACTORY_ADDRESS);
         }
         console.log("Factory address: %s", address(factory));
-        console.log("Account implementation address: %s", address(factory.accountImplementation()));
+        console.log("Account implementation address: %s", address(factory.ACCOUNT_IMPLEMENTATION()));
         vm.stopBroadcast();
     }
 }

--- a/src/account/v1/ECDSAAccount.sol
+++ b/src/account/v1/ECDSAAccount.sol
@@ -47,6 +47,7 @@ contract ECDSAAccount is CoreAccount, UUPSUpgradeable, BaseERC712CompliantAccoun
     /// @inheritdoc UUPSUpgradeable
     // The {_authorizeUpgrade} function must be overridden to include access restriction to the upgrade mechanism.
     // Authorize the owner to upgrade the contract.
+    // solhint-disable-next-line no-empty-blocks
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/src/account/v1/factory/ECDSAAccountFactory.sol
+++ b/src/account/v1/factory/ECDSAAccountFactory.sol
@@ -18,9 +18,9 @@
  */
 pragma solidity 0.8.24;
 
-import "../ECDSAAccount.sol";
-import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import "@openzeppelin/contracts/utils/Create2.sol";
+import {ECDSAAccount, IEntryPoint} from "../ECDSAAccount.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 /**
  * @dev Account factory that creates the upgradeable account signed and verified by ECDSA.
@@ -29,10 +29,10 @@ contract ECDSAAccountFactory {
     event AccountCreated(address indexed proxy, address indexed owner);
 
     // logic implementation
-    ECDSAAccount public immutable accountImplementation;
+    ECDSAAccount public immutable ACCOUNT_IMPLEMENTATION;
 
     constructor(IEntryPoint _entryPoint) {
-        accountImplementation = new ECDSAAccount(_entryPoint);
+        ACCOUNT_IMPLEMENTATION = new ECDSAAccount(_entryPoint);
     }
 
     /**
@@ -76,7 +76,7 @@ contract ECDSAAccountFactory {
         account = ECDSAAccount(
             payable(
                 new ERC1967Proxy{salt: _salt}(
-                    address(accountImplementation), abi.encodeCall(ECDSAAccount.initialize, (_owner))
+                    address(ACCOUNT_IMPLEMENTATION), abi.encodeCall(ECDSAAccount.initialize, (_owner))
                 )
             )
         );
@@ -92,7 +92,7 @@ contract ECDSAAccountFactory {
         bytes32 code = keccak256(
             abi.encodePacked(
                 type(ERC1967Proxy).creationCode,
-                abi.encode(address(accountImplementation), abi.encodeCall(ECDSAAccount.initialize, (_owner)))
+                abi.encode(address(ACCOUNT_IMPLEMENTATION), abi.encodeCall(ECDSAAccount.initialize, (_owner)))
             )
         );
         // call computeAddress(salt, bytecodeHash, address(this))

--- a/src/callback/DefaultCallbackHandler.sol
+++ b/src/callback/DefaultCallbackHandler.sol
@@ -64,5 +64,7 @@ contract DefaultCallbackHandler is IERC721Receiver, IERC1155Receiver, IERC777Rec
         uint256 amount,
         bytes calldata userData,
         bytes calldata operatorData
-    ) external pure override {}
+    ) external pure override 
+    // solhint-disable-next-line no-empty-blocks
+    {}
 }

--- a/src/common/Errors.sol
+++ b/src/common/Errors.sol
@@ -19,34 +19,10 @@
 pragma solidity 0.8.24;
 
 /**
- * @notice Throws when the selector is not found.
+ * @notice Throws when the caller is unexpected.
  */
-error NotFoundSelector();
+error UnauthorizedCaller();
 
-/**
- * @notice Throws when authorizer is invalid.
- */
-error InvalidAuthorizer();
+error InvalidLength();
 
-error InvalidValidationFunctionId(uint8 functionId);
-
-error InvalidFunctionReference();
-
-error ItemAlreadyExists();
-
-error ItemDoesNotExist();
-
-error InvalidLimit();
-
-error InvalidExecutionFunction(bytes4 selector);
-
-error InvalidInitializationInput();
-
-error Create2FailedDeployment();
-
-error NotImplemented(bytes4 selector, uint8 functionId);
-
-error InvalidItem();
-
-// v2 NotImplemented
-error NotImplementedFunction(bytes4 selector, uint32 entityId);
+error Unsupported();

--- a/src/libs/CastLib.sol
+++ b/src/libs/CastLib.sol
@@ -28,6 +28,7 @@ library CastLib {
     function toAddressArray(SetValue[] memory values) internal pure returns (address[] memory addresses) {
         bytes32[] memory valuesBytes;
 
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             valuesBytes := values
         }
@@ -37,6 +38,7 @@ library CastLib {
             valuesBytes[i] >>= 96;
         }
 
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             addresses := valuesBytes
         }

--- a/src/libs/MessageHashUtils.sol
+++ b/src/libs/MessageHashUtils.sol
@@ -38,6 +38,7 @@ library MessageHashUtils {
      */
     function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {
         /// @solidity memory-safe-assembly
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             let ptr := mload(0x40)
             mstore(ptr, hex"1901")

--- a/src/msca/6900/shared/libs/AddressDLLLib.sol
+++ b/src/msca/6900/shared/libs/AddressDLLLib.sol
@@ -117,6 +117,8 @@ library AddressDLLLib {
             results[count] = current;
             current = dll.next[current];
         }
+
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             mstore(results, count)
         }

--- a/src/msca/6900/shared/libs/Bytes4DLLLib.sol
+++ b/src/msca/6900/shared/libs/Bytes4DLLLib.sol
@@ -110,6 +110,7 @@ library Bytes4DLLLib {
             results[count] = current;
             current = dll.next[current];
         }
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             mstore(results, count)
         }

--- a/src/msca/6900/v0.7/factories/semi/SingleOwnerMSCAFactory.sol
+++ b/src/msca/6900/v0.7/factories/semi/SingleOwnerMSCAFactory.sol
@@ -31,8 +31,8 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
  */
 contract SingleOwnerMSCAFactory {
     // logic implementation
-    SingleOwnerMSCA public immutable accountImplementation;
-    IEntryPoint public immutable entryPoint;
+    SingleOwnerMSCA public immutable ACCOUNT_IMPLEMENTATION;
+    IEntryPoint public immutable ENTRY_POINT;
 
     event FactoryDeployed(address indexed factory, address accountImplementation, address entryPoint);
     event AccountCreated(address indexed proxy, address sender, bytes32 salt);
@@ -46,10 +46,10 @@ contract SingleOwnerMSCAFactory {
      *      of more complicated plugins, please call installPlugin via a separate tx/userOp after account deployment.
      */
     constructor(address _entryPointAddr, address _pluginManagerAddr) {
-        entryPoint = IEntryPoint(_entryPointAddr);
+        ENTRY_POINT = IEntryPoint(_entryPointAddr);
         PluginManager _pluginManager = PluginManager(_pluginManagerAddr);
-        accountImplementation = new SingleOwnerMSCA(entryPoint, _pluginManager);
-        emit FactoryDeployed(address(this), address(accountImplementation), _entryPointAddr);
+        ACCOUNT_IMPLEMENTATION = new SingleOwnerMSCA(ENTRY_POINT, _pluginManager);
+        emit FactoryDeployed(address(this), address(ACCOUNT_IMPLEMENTATION), _entryPointAddr);
     }
 
     /**
@@ -82,7 +82,7 @@ contract SingleOwnerMSCAFactory {
         account = SingleOwnerMSCA(
             payable(
                 new ERC1967Proxy{salt: mixedSalt}(
-                    address(accountImplementation), abi.encodeCall(SingleOwnerMSCA.initializeSingleOwnerMSCA, (owner))
+                    address(ACCOUNT_IMPLEMENTATION), abi.encodeCall(SingleOwnerMSCA.initializeSingleOwnerMSCA, (owner))
                 )
             )
         );
@@ -136,7 +136,7 @@ contract SingleOwnerMSCAFactory {
             abi.encodePacked(
                 type(ERC1967Proxy).creationCode,
                 abi.encode(
-                    address(accountImplementation), abi.encodeCall(SingleOwnerMSCA.initializeSingleOwnerMSCA, (_owner))
+                    address(ACCOUNT_IMPLEMENTATION), abi.encodeCall(SingleOwnerMSCA.initializeSingleOwnerMSCA, (_owner))
                 )
             )
         );

--- a/src/msca/6900/v0.7/interfaces/IAccountLoupe.sol
+++ b/src/msca/6900/v0.7/interfaces/IAccountLoupe.sol
@@ -18,7 +18,7 @@
  */
 pragma solidity 0.8.24;
 
-import "../common/Structs.sol";
+import {ExecutionFunctionConfig, ExecutionHooks, FunctionReference} from "../common/Structs.sol";
 
 /**
  * @dev Implements https://eips.ethereum.org/EIPS/eip-6900. MSCAs may implement this interface to support visibility in

--- a/src/msca/6900/v0.7/interfaces/IPlugin.sol
+++ b/src/msca/6900/v0.7/interfaces/IPlugin.sol
@@ -18,8 +18,7 @@
  */
 pragma solidity 0.8.24;
 
-import "../common/PluginManifest.sol";
-import "../common/Structs.sol";
+import {PluginManifest, PluginMetadata} from "../common/PluginManifest.sol";
 import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
 
 /**

--- a/src/msca/6900/v0.7/interfaces/IPluginManager.sol
+++ b/src/msca/6900/v0.7/interfaces/IPluginManager.sol
@@ -18,7 +18,7 @@
  */
 pragma solidity 0.8.24;
 
-import "../common/Structs.sol";
+import {FunctionReference} from "../common/Structs.sol";
 
 /**
  * @dev Implements https://eips.ethereum.org/EIPS/eip-6900. MSCAs must implement this interface to support installing

--- a/src/msca/6900/v0.7/interfaces/IStandardExecutor.sol
+++ b/src/msca/6900/v0.7/interfaces/IStandardExecutor.sol
@@ -18,7 +18,7 @@
  */
 pragma solidity 0.8.24;
 
-import "../common/Structs.sol";
+import {Call} from "../common/Structs.sol";
 
 /**
  * @dev Implements https://eips.ethereum.org/EIPS/eip-6900. MSCAs must implement this interface to support open-ended

--- a/src/msca/6900/v0.7/libs/FunctionReferenceDLLLib.sol
+++ b/src/msca/6900/v0.7/libs/FunctionReferenceDLLLib.sol
@@ -22,7 +22,7 @@ import {EMPTY_FUNCTION_REFERENCE, SENTINEL_BYTES21} from "../../../../common/Con
 import {
     InvalidFunctionReference, InvalidLimit, ItemAlreadyExists, ItemDoesNotExist
 } from "../../shared/common/Errors.sol";
-import "../common/Structs.sol";
+import {Bytes21DLL, FunctionReference} from "../common/Structs.sol";
 import {FunctionReferenceLib} from "./FunctionReferenceLib.sol";
 
 /**
@@ -130,6 +130,7 @@ library FunctionReferenceDLLLib {
             results[count] = current.unpack();
             current = dll.next[current];
         }
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             mstore(results, count)
         }

--- a/src/msca/6900/v0.7/libs/FunctionReferenceLib.sol
+++ b/src/msca/6900/v0.7/libs/FunctionReferenceLib.sol
@@ -18,7 +18,7 @@
  */
 pragma solidity 0.8.24;
 
-import "../common/Structs.sol";
+import {FunctionReference} from "../common/Structs.sol";
 
 library FunctionReferenceLib {
     function unpack(bytes21 frBytes) internal pure returns (FunctionReference memory) {

--- a/src/msca/6900/v0.7/libs/RepeatableFunctionReferenceDLLLib.sol
+++ b/src/msca/6900/v0.7/libs/RepeatableFunctionReferenceDLLLib.sol
@@ -20,7 +20,7 @@ pragma solidity 0.8.24;
 
 import {EMPTY_FUNCTION_REFERENCE, SENTINEL_BYTES21} from "../../../../common/Constants.sol";
 import {InvalidFunctionReference, InvalidLimit, ItemDoesNotExist} from "../../shared/common/Errors.sol";
-import "../common/Structs.sol";
+import {FunctionReference, RepeatableBytes21DLL} from "../common/Structs.sol";
 import {FunctionReferenceLib} from "./FunctionReferenceLib.sol";
 
 /**
@@ -176,6 +176,7 @@ library RepeatableFunctionReferenceDLLLib {
             results[count] = current.unpack();
             current = dll.next[current];
         }
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             mstore(results, count)
         }

--- a/src/msca/6900/v0.7/libs/SelectorRegistryLib.sol
+++ b/src/msca/6900/v0.7/libs/SelectorRegistryLib.sol
@@ -28,6 +28,9 @@ import {IAggregator} from "@account-abstraction/contracts/interfaces/IAggregator
 import {IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
+import {IERC777Recipient} from "@openzeppelin/contracts/interfaces/IERC777Recipient.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 library SelectorRegistryLib {
@@ -62,7 +65,10 @@ library SelectorRegistryLib {
             || selector == IAccountLoupe.getInstalledPlugins.selector || selector == VALIDATE_USER_OP
             || selector == GET_ENTRYPOINT || selector == GET_NONCE || selector == INITIALIZE_UPGRADABLE_MSCA
             || selector == INITIALIZE_SINGLE_OWNER_MSCA || selector == TRANSFER_NATIVE_OWNERSHIP
-            || selector == RENOUNCE_NATIVE_OWNERSHIP || selector == GET_NATIVE_OWNER;
+            || selector == RENOUNCE_NATIVE_OWNERSHIP || selector == GET_NATIVE_OWNER
+            || selector == IERC1155Receiver.onERC1155Received.selector
+            || selector == IERC1155Receiver.onERC1155BatchReceived.selector
+            || selector == IERC721Receiver.onERC721Received.selector || selector == IERC777Recipient.tokensReceived.selector;
     }
 
     function _isErc4337FunctionSelector(bytes4 selector) internal pure returns (bool) {

--- a/src/msca/6900/v0.7/libs/WalletStorageV1Lib.sol
+++ b/src/msca/6900/v0.7/libs/WalletStorageV1Lib.sol
@@ -19,7 +19,7 @@
 pragma solidity 0.8.24;
 
 import {AddressDLL} from "../../shared/common/Structs.sol";
-import "../common/Structs.sol";
+import {ExecutionDetail, PermittedExternalCall, PluginDetail} from "../common/Structs.sol";
 
 /// @dev The same storage will be used for v1.x.y of MSCAs.
 library WalletStorageV1Lib {
@@ -54,6 +54,7 @@ library WalletStorageV1Lib {
      * @dev Function to read structured wallet storage.
      */
     function getLayout() internal pure returns (Layout storage walletStorage) {
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             walletStorage.slot := WALLET_STORAGE_SLOT
         }

--- a/src/msca/6900/v0.7/managers/PluginExecutor.sol
+++ b/src/msca/6900/v0.7/managers/PluginExecutor.sol
@@ -20,7 +20,7 @@ pragma solidity 0.8.24;
 
 import {ExecutionUtils} from "../../../../utils/ExecutionUtils.sol";
 import {InvalidExecutionFunction, NotFoundSelector} from "../../shared/common/Errors.sol";
-import "../common/Structs.sol";
+import {ExecutionDetail, HookGroup, PermittedExternalCall, PostExecHookToRun} from "../common/Structs.sol";
 import {IPlugin} from "../interfaces/IPlugin.sol";
 import {IPluginExecutor} from "../interfaces/IPluginExecutor.sol";
 import {ExecutionHookLib} from "../libs/ExecutionHookLib.sol";

--- a/src/msca/6900/v0.7/managers/PluginManager.sol
+++ b/src/msca/6900/v0.7/managers/PluginManager.sol
@@ -26,8 +26,20 @@ import {
     PRE_HOOK_ALWAYS_DENY_FUNCTION_REFERENCE,
     RUNTIME_VALIDATION_ALWAYS_ALLOW_FUNCTION_REFERENCE
 } from "../common/Constants.sol";
-import "../common/PluginManifest.sol";
-import "../common/Structs.sol";
+import {
+    ManifestAssociatedFunctionType,
+    ManifestExecutionHook,
+    ManifestExternalCallPermission,
+    ManifestFunction,
+    PluginManifest
+} from "../common/PluginManifest.sol";
+import {
+    Bytes21DLL,
+    FunctionReference,
+    HookGroup,
+    PermittedExternalCall,
+    RepeatableBytes21DLL
+} from "../common/Structs.sol";
 import {IPlugin} from "../interfaces/IPlugin.sol";
 import {FunctionReferenceDLLLib} from "../libs/FunctionReferenceDLLLib.sol";
 import {FunctionReferenceLib} from "../libs/FunctionReferenceLib.sol";
@@ -49,7 +61,7 @@ contract PluginManager {
     using SelectorRegistryLib for bytes4;
 
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
-    address private immutable __self = address(this);
+    address private immutable SELF = address(this);
 
     enum AssociatedFunctionType {
         HOOK,
@@ -71,7 +83,7 @@ contract PluginManager {
     error InvalidExecutionSelector(address plugin, bytes4 selector);
 
     modifier onlyDelegated() {
-        if (address(this) == __self) {
+        if (address(this) == SELF) {
             revert OnlyDelegated();
         }
         _;

--- a/src/msca/6900/v0.7/managers/StandardExecutor.sol
+++ b/src/msca/6900/v0.7/managers/StandardExecutor.sol
@@ -19,7 +19,7 @@
 pragma solidity 0.8.24;
 
 import {ExecutionUtils} from "../../../../utils/ExecutionUtils.sol";
-import "../common/Structs.sol";
+import {Call} from "../common/Structs.sol";
 import {IPlugin} from "../interfaces/IPlugin.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 

--- a/src/msca/6900/v0.7/plugins/BasePlugin.sol
+++ b/src/msca/6900/v0.7/plugins/BasePlugin.sol
@@ -19,8 +19,7 @@
 pragma solidity 0.8.24;
 
 import {NotImplemented} from "../../shared/common/Errors.sol";
-import "../common/PluginManifest.sol";
-import "../common/Structs.sol";
+import {PluginManifest, PluginMetadata} from "../common/PluginManifest.sol";
 import {IPlugin} from "../interfaces/IPlugin.sol";
 import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol
+++ b/src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol
@@ -26,9 +26,17 @@ import {
     SIG_VALIDATION_FAILED,
     SIG_VALIDATION_SUCCEEDED
 } from "../../../../../../common/Constants.sol";
-import {InvalidValidationFunctionId, UnauthorizedCaller} from "../../../../shared/common/Errors.sol";
-import "../../../common/PluginManifest.sol";
-import "../../../common/Structs.sol";
+
+import {UnauthorizedCaller} from "../../../../../../common/Errors.sol";
+import {InvalidValidationFunctionId} from "../../../../shared/common/Errors.sol";
+import {
+    ManifestAssociatedFunction,
+    ManifestAssociatedFunctionType,
+    ManifestFunction,
+    PluginManifest,
+    PluginMetadata,
+    SelectorPermission
+} from "../../../common/PluginManifest.sol";
 import {IPluginManager} from "../../../interfaces/IPluginManager.sol";
 import {IStandardExecutor} from "../../../interfaces/IStandardExecutor.sol";
 import {BasePlugin} from "../../BasePlugin.sol";

--- a/src/msca/6900/v0.7/plugins/v1_0_0/addressbook/AddressBookPlugin.sol
+++ b/src/msca/6900/v0.7/plugins/v1_0_0/addressbook/AddressBookPlugin.sol
@@ -24,10 +24,17 @@ import {
     SIG_VALIDATION_FAILED,
     SIG_VALIDATION_SUCCEEDED
 } from "../../../../../../common/Constants.sol";
+
+import {InvalidLength, Unsupported} from "../../../../../../common/Errors.sol";
 import {CastLib} from "../../../../../../libs/CastLib.sol";
-import {InvalidLength, Unsupported} from "../../../../shared/common/Errors.sol";
-import "../../../common/PluginManifest.sol";
-import "../../../common/Structs.sol";
+import {
+    ManifestAssociatedFunction,
+    ManifestAssociatedFunctionType,
+    ManifestFunction,
+    PluginManifest,
+    PluginMetadata,
+    SelectorPermission
+} from "../../../common/PluginManifest.sol";
 import {IPlugin} from "../../../interfaces/IPlugin.sol";
 import {IPluginExecutor} from "../../../interfaces/IPluginExecutor.sol";
 import {IStandardExecutor} from "../../../interfaces/IStandardExecutor.sol";

--- a/src/msca/6900/v0.7/plugins/v1_0_0/addressbook/ColdStorageAddressBookPlugin.sol
+++ b/src/msca/6900/v0.7/plugins/v1_0_0/addressbook/ColdStorageAddressBookPlugin.sol
@@ -18,6 +18,7 @@
  */
 pragma solidity 0.8.24;
 
+import {Unsupported} from "../../../../../../common//Errors.sol";
 import {
     PLUGIN_AUTHOR,
     PLUGIN_VERSION_1,
@@ -26,7 +27,6 @@ import {
 } from "../../../../../../common/Constants.sol";
 import {CastLib} from "../../../../../../libs/CastLib.sol";
 import {RecipientAddressLib} from "../../../../../../libs/RecipientAddressLib.sol";
-import {Unsupported} from "../../../../shared/common/Errors.sol";
 import {
     ManifestAssociatedFunction,
     ManifestAssociatedFunctionType,

--- a/src/msca/6900/v0.7/plugins/v1_0_0/multisig/BaseMultisigPlugin.sol
+++ b/src/msca/6900/v0.7/plugins/v1_0_0/multisig/BaseMultisigPlugin.sol
@@ -124,6 +124,7 @@ abstract contract BaseMultisigPlugin is BasePlugin {
     /// @return minimal user op hash
     function _getMinimalUserOpDigest(UserOperation calldata userOp) internal view returns (bytes32) {
         address sender;
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             sender := calldataload(userOp)
         }
@@ -151,6 +152,7 @@ abstract contract BaseMultisigPlugin is BasePlugin {
 
     /// @param data calldata to hash
     function _calldataKeccak(bytes calldata data) internal pure returns (bytes32 ret) {
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             let mem := mload(0x40)
             let len := data.length
@@ -176,6 +178,7 @@ abstract contract BaseMultisigPlugin is BasePlugin {
         pure
         returns (uint8 v, bytes32 r, bytes32 s)
     {
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             let signaturePos := mul(0x41, pos)
             r := mload(add(signatures, add(signaturePos, 0x20)))

--- a/src/msca/6900/v0.7/plugins/v1_0_0/multisig/WeightedWebauthnMultisigPlugin.sol
+++ b/src/msca/6900/v0.7/plugins/v1_0_0/multisig/WeightedWebauthnMultisigPlugin.sol
@@ -412,6 +412,7 @@ contract WeightedWebauthnMultisigPlugin is BaseWeightedMultisigPlugin, BaseERC71
                     uint256 sigDynamicPartTotalLen;
                     // 1. load contractSignature content starting from the correct memory offset
                     // 2. calculate total length including the content and the prefix storing the length
+                    // solhint-disable-next-line no-inline-assembly
                     assembly ("memory-safe") {
                         contractSignature := add(add(signatures, sigDynamicPartOffset), 0x20)
                         sigDynamicPartTotalLen := add(mload(contractSignature), 0x20)
@@ -452,6 +453,7 @@ contract WeightedWebauthnMultisigPlugin is BaseWeightedMultisigPlugin, BaseERC71
                     uint256 sigDynamicPartTotalLen;
                     // 1. load the content starting from the correct memory offset
                     // 2. calculate total length including the content and the prefix storing the length
+                    // solhint-disable-next-line no-inline-assembly
                     assembly ("memory-safe") {
                         sigDynamicPartBytes := add(add(signatures, sigDynamicPartOffset), 0x20)
                         sigDynamicPartTotalLen := add(mload(sigDynamicPartBytes), 0x20)

--- a/src/msca/6900/v0.7/plugins/v1_0_0/utility/DefaultTokenCallbackPlugin.sol
+++ b/src/msca/6900/v0.7/plugins/v1_0_0/utility/DefaultTokenCallbackPlugin.sol
@@ -78,7 +78,9 @@ contract DefaultTokenCallbackPlugin is BasePlugin, IERC721Receiver, IERC1155Rece
         uint256 amount,
         bytes calldata userData,
         bytes calldata operatorData
-    ) external pure override {}
+    ) external pure override 
+    // solhint-disable-next-line no-empty-blocks
+    {}
 
     /// @inheritdoc BasePlugin
     function pluginManifest() external pure override returns (PluginManifest memory) {

--- a/src/paymaster/v1/permissioned/SponsorPaymaster.sol
+++ b/src/paymaster/v1/permissioned/SponsorPaymaster.sol
@@ -18,15 +18,12 @@
  */
 pragma solidity 0.8.24;
 
-/* solhint-disable reason-string */
+import {PaymasterUtils, UserOperationLib} from "../../../utils/PaymasterUtils.sol";
 
-import "../../../utils/PaymasterUtils.sol";
-
-import "../../BasePaymaster.sol";
+import {BasePaymaster, UserOperation} from "../../BasePaymaster.sol";
 import {_packValidationData} from "@account-abstraction/contracts/core/Helpers.sol";
-import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
-import "@account-abstraction/contracts/interfaces/IPaymaster.sol";
-import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /**

--- a/src/utils/ExecutionUtils.sol
+++ b/src/utils/ExecutionUtils.sol
@@ -18,8 +18,6 @@
  */
 pragma solidity 0.8.24;
 
-// solhint-disable no-inline-assembly
-
 /**
  * Utility functions helpful when making different kinds of contract calls in Solidity.
  * For inline assembly, please refer to https://docs.soliditylang.org/en/latest/assembly.html
@@ -30,6 +28,7 @@ library ExecutionUtils {
         internal
         returns (bool success, bytes memory returnData)
     {
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             success := call(gas(), to, value, add(data, 0x20), mload(data), 0, 0)
             let len := returndatasize()
@@ -42,6 +41,7 @@ library ExecutionUtils {
     }
 
     function revertWithData(bytes memory returnData) internal pure {
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             revert(add(returnData, 32), mload(returnData))
         }
@@ -65,6 +65,7 @@ library ExecutionUtils {
 
     /// @dev Return data or revert.
     function delegateCall(address to, bytes memory data) internal returns (bytes memory) {
+        // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory returnData) = to.delegatecall(data);
         if (!success) {
             // bubble up revert reason
@@ -83,6 +84,7 @@ library ExecutionUtils {
     /// ensuring the memory is pushed to the nearest multiple of 32 bytes. This avoids unaligned memory access,
     /// which can lead to inefficiencies.
     function fetchReturnData() internal pure returns (bytes memory returnData) {
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             // allocate memory for the return data starting at the free memory pointer
             returnData := mload(0x40)

--- a/src/utils/PaymasterUtils.sol
+++ b/src/utils/PaymasterUtils.sol
@@ -18,9 +18,6 @@
  */
 pragma solidity 0.8.24;
 
-/* solhint-disable reason-string */
-/* solhint-disable no-inline-assembly */
-
 import {UserOperation, UserOperationLib} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
 
 enum ChargeMode {
@@ -99,6 +96,7 @@ library PaymasterUtils {
      * do it.
      */
     function calldataKeccak(bytes calldata data) internal pure returns (bytes32 ret) {
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             let mem := mload(0x40)
             let len := data.length

--- a/test/ECDSAAccountAndFactory.t.sol
+++ b/test/ECDSAAccountAndFactory.t.sol
@@ -21,6 +21,7 @@ pragma solidity 0.8.24;
 import {ECDSAAccountFactory} from "../src/account/v1/factory/ECDSAAccountFactory.sol";
 
 import {ECDSAAccount} from "../src/account/v1/ECDSAAccount.sol";
+import {InvalidLength, UnauthorizedCaller} from "../src/common/Errors.sol";
 import {TestERC1155} from "./util/TestERC1155.sol";
 import {TestERC721} from "./util/TestERC721.sol";
 import {TestLiquidityPool} from "./util/TestLiquidityPool.sol";
@@ -63,7 +64,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
     uint256 internal eoaPrivateKey;
     address private ownerAddr;
     ECDSAAccountFactory private ecdsaAccountFactory;
-    address payable beneficiary; // e.g. bundler
+    address payable private beneficiary; // e.g. bundler
     TestLiquidityPool private testLiquidityPool;
     TestERC1155 private testERC1155;
     TestERC721 private testERC721;
@@ -403,7 +404,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
 
         // upgrade via random address
         vm.startPrank(address(1));
-        vm.expectRevert(bytes("Caller is not the owner"));
+        vm.expectRevert(UnauthorizedCaller.selector);
         proxy.upgradeToAndCall(v2ImplAddr, "");
         vm.stopPrank();
     }
@@ -459,7 +460,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
         value[1] = 10;
 
         vm.startPrank(ownerAddr);
-        vm.expectRevert(bytes("wrong array lengths"));
+        vm.expectRevert(InvalidLength.selector);
         proxy.executeBatch(dest, value, func);
         vm.stopPrank();
 
@@ -473,7 +474,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
         func2[1] = transferCallData;
 
         vm.startPrank(ownerAddr);
-        vm.expectRevert(bytes("wrong array lengths"));
+        vm.expectRevert(InvalidLength.selector);
         proxy.executeBatch(dest2, value2, func2);
         vm.stopPrank();
     }
@@ -612,7 +613,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
 
         // only owner can withdraw
         vm.startPrank(randomAddr);
-        vm.expectRevert("Caller is not the owner");
+        vm.expectRevert(UnauthorizedCaller.selector);
         proxy.withdrawDepositTo(payable(randomAddr), 1);
         vm.stopPrank();
     }
@@ -660,7 +661,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
         address sender = address(proxy);
         (address randomAddr) = makeAddr("randomAccount");
         vm.startPrank(randomAddr);
-        vm.expectRevert("Caller is not the owner");
+        vm.expectRevert(UnauthorizedCaller.selector);
         proxy.pause();
         vm.stopPrank();
 
@@ -759,7 +760,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
         assertEq(sender.balance, 900000000000000000);
         // hacker
         vm.startPrank(vm.addr(123));
-        vm.expectRevert(bytes("account: not EntryPoint or Owner"));
+        vm.expectRevert(UnauthorizedCaller.selector);
         senderAccount.execute(recipient, 100, "");
         vm.stopPrank();
     }
@@ -781,7 +782,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
         assertEq(sender.balance, 900000000000000000);
         // hacker
         vm.startPrank(vm.addr(456));
-        vm.expectRevert(bytes("account: not EntryPoint or Owner"));
+        vm.expectRevert(UnauthorizedCaller.selector);
         senderAccount.execute(recipient, 100, "");
         vm.stopPrank();
     }
@@ -806,7 +807,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
 
         // hacker
         vm.startPrank(vm.addr(123));
-        vm.expectRevert(bytes("account: not EntryPoint or Owner"));
+        vm.expectRevert(UnauthorizedCaller.selector);
         senderAccount.execute(liquidityPoolSpenderAddr, 0, transferCallData);
         vm.stopPrank();
     }
@@ -831,7 +832,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
 
         // hacker
         vm.startPrank(vm.addr(123));
-        vm.expectRevert(bytes("account: not EntryPoint or Owner"));
+        vm.expectRevert(UnauthorizedCaller.selector);
         senderAccount.execute(liquidityPoolSpenderAddr, 0, transferCallData);
         vm.stopPrank();
     }
@@ -856,7 +857,7 @@ contract ECDSAAccountAndFactoryTest is TestUtils {
 
         // hacker
         vm.startPrank(vm.addr(123));
-        vm.expectRevert(bytes("account: not EntryPoint or Owner"));
+        vm.expectRevert(UnauthorizedCaller.selector);
         senderAccount.execute(liquidityPoolSpenderAddr, 0, transferCallData);
         vm.stopPrank();
     }

--- a/test/SponsorPaymaster.t.sol
+++ b/test/SponsorPaymaster.t.sol
@@ -18,13 +18,16 @@
  */
 pragma solidity 0.8.24;
 
-import "../src/paymaster/v1/permissioned/SponsorPaymaster.sol";
+import {SponsorPaymaster} from "../src/paymaster/v1/permissioned/SponsorPaymaster.sol";
+import {_packValidationData} from "@account-abstraction/contracts/core/Helpers.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {UserOperation, UserOperationLib} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
-import "./util/TestUtils.sol";
+import {TestUtils} from "./util/TestUtils.sol";
 
-import "@account-abstraction/contracts/core/EntryPoint.sol";
-import "@account-abstraction/contracts/interfaces/IPaymaster.sol";
-import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract SponsorPaymasterTest is TestUtils {
     using UserOperationLib for UserOperation;
@@ -38,9 +41,9 @@ contract SponsorPaymasterTest is TestUtils {
     uint256 internal verifyingSigner2PrivateKey = 0xdef;
     address internal verifyingSigner1;
     address internal verifyingSigner2;
-    uint48 internal MOCK_VALID_UNTIL = 1691493273;
-    uint48 internal MOCK_VALID_AFTER = 1681493273;
-    bytes internal MOCK_OFFCHAIN_SIG = "0x123456";
+    uint48 internal constant MOCK_VALID_UNTIL = 1691493273;
+    uint48 internal constant MOCK_VALID_AFTER = 1681493273;
+    bytes internal constant MOCK_OFFCHAIN_SIG = "0x123456";
 
     function setUp() public {
         verifyingSigner1 = vm.addr(verifyingSigner1PrivateKey);

--- a/test/WalletMigration.t.sol
+++ b/test/WalletMigration.t.sol
@@ -21,14 +21,16 @@ pragma solidity 0.8.24;
 import {ECDSAAccount} from "../src/account/v1/ECDSAAccount.sol";
 import {ECDSAAccountFactory} from "../src/account/v1/factory/ECDSAAccountFactory.sol";
 import {FunctionReference} from "../src/msca/6900/v0.7/common/Structs.sol";
-import "../src/msca/6900/v0.7/factories/semi/SingleOwnerMSCAFactory.sol";
-import "../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
-import "../src/msca/6900/v0.7/libs/FunctionReferenceLib.sol";
-import "../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
-import "./util/TestERC1155.sol";
-import "./util/TestERC721.sol";
+import {SingleOwnerMSCAFactory} from "../src/msca/6900/v0.7/factories/semi/SingleOwnerMSCAFactory.sol";
+import {FunctionReferenceLib} from "../src/msca/6900/v0.7/libs/FunctionReferenceLib.sol";
+import {TestERC1155} from "./util/TestERC1155.sol";
+import {TestERC721} from "./util/TestERC721.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {SingleOwnerMSCA} from "src/msca/6900/v0.7/account/semi/SingleOwnerMSCA.sol";
+import {PluginManager} from "src/msca/6900/v0.7/managers/PluginManager.sol";
 
-import "./util/TestLiquidityPool.sol";
+import {TestLiquidityPool} from "./util/TestLiquidityPool.sol";
 import {TestUtils} from "./util/TestUtils.sol";
 import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
 

--- a/test/gas/6900/v0.7/plugins/addressbook/SingleOwnerMSCAWithAddressBookPlugin.t.sol
+++ b/test/gas/6900/v0.7/plugins/addressbook/SingleOwnerMSCAWithAddressBookPlugin.t.sol
@@ -20,9 +20,16 @@ pragma solidity 0.8.24;
 
 import {FunctionReference} from "../../../../../../src/msca/6900/v0.7/common/Structs.sol";
 
-import "../../../../../../src/msca/6900/v0.7/factories/semi/SingleOwnerMSCAFactory.sol";
-import "../../../../../../src/msca/6900/v0.7/plugins/v1_0_0/addressbook/AddressBookPlugin.sol";
-import "../../../../../../src/utils/ExecutionUtils.sol";
+import {
+    PluginManager,
+    SingleOwnerMSCA,
+    SingleOwnerMSCAFactory
+} from "../../../../../../src/msca/6900/v0.7/factories/semi/SingleOwnerMSCAFactory.sol";
+import {
+    AddressBookPlugin,
+    IAddressBookPlugin,
+    UserOperation
+} from "../../../../../../src/msca/6900/v0.7/plugins/v1_0_0/addressbook/AddressBookPlugin.sol";
 import {PluginGasProfileBaseTest} from "../../../../PluginGasProfileBase.t.sol";
 
 contract SingleOwnerMSCAWithAddressBookPluginTest is PluginGasProfileBaseTest {

--- a/test/gas/6900/v0.7/plugins/singleowner/SingleOwnerMSCAWithSingleOwnerPlugin.t.sol
+++ b/test/gas/6900/v0.7/plugins/singleowner/SingleOwnerMSCAWithSingleOwnerPlugin.t.sol
@@ -18,12 +18,15 @@
  */
 pragma solidity 0.8.24;
 
-import "../../../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {FunctionReference} from "../../../../../../src/msca/6900/v0.7/common/Structs.sol";
 
-import "../../../../../../src/msca/6900/v0.7/factories/semi/SingleOwnerMSCAFactory.sol";
-import "../../../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
-import "../../../../../../src/utils/ExecutionUtils.sol";
-import "../../../../PluginGasProfileBase.t.sol";
+import {
+    PluginManager,
+    SingleOwnerMSCA,
+    SingleOwnerMSCAFactory
+} from "../../../../../../src/msca/6900/v0.7/factories/semi/SingleOwnerMSCAFactory.sol";
+import {SingleOwnerPlugin} from "../../../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
+import {PluginGasProfileBaseTest, UserOperation} from "../../../../PluginGasProfileBase.t.sol";
 
 contract SingleOwnerMSCAWithSingleOwnerPluginTest is PluginGasProfileBaseTest {
     event PluginInstalled(address indexed plugin, bytes32 manifestHash, FunctionReference[] dependencies);

--- a/test/gas/6900/v0.7/plugins/singleowner/UpgradableMSCAWithSingleOwnerPlugin.t.sol
+++ b/test/gas/6900/v0.7/plugins/singleowner/UpgradableMSCAWithSingleOwnerPlugin.t.sol
@@ -18,13 +18,18 @@
  */
 pragma solidity 0.8.24;
 
-import "../../../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {FunctionReference} from "../../../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {console} from "forge-std/src/console.sol";
 
-import "../../../../../../src/msca/6900/v0.7/factories/UpgradableMSCAFactory.sol";
-import "../../../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
-import "../../../../../../src/utils/ExecutionUtils.sol";
+import {
+    PluginManager,
+    UpgradableMSCA,
+    UpgradableMSCAFactory
+} from "../../../../../../src/msca/6900/v0.7/factories/UpgradableMSCAFactory.sol";
+import {SingleOwnerPlugin} from "../../../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
+import {ExecutionUtils} from "../../../../../../src/utils/ExecutionUtils.sol";
 import {TestUserOpAllPassValidator} from "../../../../../msca/6900/v0.7/TestUserOpAllPassValidator.sol";
-import "../../../../PluginGasProfileBase.t.sol";
+import {PluginGasProfileBaseTest, UserOperation} from "../../../../PluginGasProfileBase.t.sol";
 
 contract UpgradableMSCAWithSingleOwnerPluginTest is PluginGasProfileBaseTest {
     event PluginInstalled(address indexed plugin, bytes32 manifestHash, FunctionReference[] dependencies);

--- a/test/gas/PluginGasProfileBase.t.sol
+++ b/test/gas/PluginGasProfileBase.t.sol
@@ -25,12 +25,12 @@ import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOpera
 import {console} from "forge-std/src/console.sol";
 
 abstract contract PluginGasProfileBaseTest is TestUtils {
-    uint256 constant OV_PER_ZERO_BYTE = 4;
-    uint256 constant OV_PER_NONZERO_BYTE = 16;
+    uint256 private constant OV_PER_ZERO_BYTE = 4;
+    uint256 private constant OV_PER_NONZERO_BYTE = 16;
     IEntryPoint public entryPoint = new EntryPoint();
     address payable public beneficiary = payable(address(makeAddr("bundler")));
-    string jsonObj;
-    uint256 sum;
+    string internal jsonObj;
+    uint256 internal sum;
     bool public writeGasProfileToFile;
 
     function testBenchmarkAll() external virtual;

--- a/test/msca/6900/shared/libs/Bytes32DLLLib.t.sol
+++ b/test/msca/6900/shared/libs/Bytes32DLLLib.t.sol
@@ -18,60 +18,17 @@
  */
 pragma solidity 0.8.24;
 
-/* solhint-disable one-contract-per-file */
-
 import {SENTINEL_BYTES32} from "../../../../../src/common/Constants.sol";
 import {Bytes32DLL} from "../../../../../src/msca/6900/shared/common/Structs.sol";
 import {Bytes32DLLLib} from "../../../../../src/msca/6900/shared/libs/Bytes32DLLLib.sol";
 import {TestUtils} from "../../../../util/TestUtils.sol";
-
-contract TestDLL {
-    using Bytes32DLLLib for Bytes32DLL;
-
-    Bytes32DLL private bytes32DLL;
-
-    function append(bytes32 valueToAdd) external returns (bool) {
-        return bytes32DLL.append(valueToAdd);
-    }
-
-    function remove(bytes32 valueToRemove) external returns (bool) {
-        return bytes32DLL.remove(valueToRemove);
-    }
-
-    function size() external view returns (uint256) {
-        return bytes32DLL.size();
-    }
-
-    function contains(bytes32 value) external view returns (bool) {
-        return bytes32DLL.contains(value);
-    }
-
-    function getAll() external view returns (bytes32[] memory results) {
-        return bytes32DLL.getAll();
-    }
-
-    function getPaginated(bytes32 start, uint256 limit)
-        external
-        view
-        returns (bytes32[] memory results, bytes32 next)
-    {
-        return bytes32DLL.getPaginated(start, limit);
-    }
-
-    function getHead() external view returns (bytes32) {
-        return bytes32DLL.getHead();
-    }
-
-    function getTail() external view returns (bytes32) {
-        return bytes32DLL.getTail();
-    }
-}
+import {TestBytes32DLL} from "./TestBytes32DLL.sol";
 
 contract Bytes32DLLLibTest is TestUtils {
     using Bytes32DLLLib for Bytes32DLL;
 
     function testAddRemoveGetBytes32Values() public {
-        TestDLL values = new TestDLL();
+        TestBytes32DLL values = new TestBytes32DLL();
         // sentinel value is initialized
         assertEq(values.size(), 0);
         // try to remove sentinel stupidly
@@ -152,14 +109,14 @@ contract Bytes32DLLLibTest is TestUtils {
         // try out different limits, even bigger than totalValues
         bound(limit, 1, 30);
         bound(totalValues, 3, 30);
-        TestDLL dll = new TestDLL();
+        TestBytes32DLL dll = new TestBytes32DLL();
         for (uint32 i = 1; i <= totalValues; i++) {
             dll.append(bytes32(uint256(i)));
         }
         bulkGetAndVerifyValues(dll, totalValues, limit);
     }
 
-    function bulkGetAndVerifyValues(TestDLL dll, uint256 totalValues, uint256 limit) private view {
+    function bulkGetAndVerifyValues(TestBytes32DLL dll, uint256 totalValues, uint256 limit) private view {
         bytes32[] memory results = new bytes32[](totalValues);
         bytes32 start = SENTINEL_BYTES32;
         uint32 count = 0;

--- a/test/msca/6900/shared/libs/Bytes4DLLLib.t.sol
+++ b/test/msca/6900/shared/libs/Bytes4DLLLib.t.sol
@@ -24,50 +24,13 @@ import {SENTINEL_BYTES4} from "../../../../../src/common/Constants.sol";
 import {Bytes4DLL} from "../../../../../src/msca/6900/shared/common/Structs.sol";
 import {Bytes4DLLLib} from "../../../../../src/msca/6900/shared/libs/Bytes4DLLLib.sol";
 import {TestUtils} from "../../../../util/TestUtils.sol";
-
-contract TestDLL {
-    using Bytes4DLLLib for Bytes4DLL;
-
-    Bytes4DLL private bytes4DLL;
-
-    function append(bytes4 valueToAdd) external returns (bool) {
-        return bytes4DLL.append(valueToAdd);
-    }
-
-    function remove(bytes4 valueToRemove) external returns (bool) {
-        return bytes4DLL.remove(valueToRemove);
-    }
-
-    function size() external view returns (uint256) {
-        return bytes4DLL.size();
-    }
-
-    function contains(bytes4 value) external returns (bool) {
-        return bytes4DLL.contains(value);
-    }
-
-    function getAll() external view returns (bytes4[] memory results) {
-        return bytes4DLL.getAll();
-    }
-
-    function getPaginated(bytes4 start, uint256 limit) external view returns (bytes4[] memory results, bytes4 next) {
-        return bytes4DLL.getPaginated(start, limit);
-    }
-
-    function getHead() external view returns (bytes4) {
-        return bytes4DLL.getHead();
-    }
-
-    function getTail() external view returns (bytes4) {
-        return bytes4DLL.getTail();
-    }
-}
+import {TestBytes4DLL} from "./TestBytes4DLL.sol";
 
 contract Bytes4DLLLibTest is TestUtils {
     using Bytes4DLLLib for Bytes4DLL;
 
     function testAddRemoveGetBytes4Values() public {
-        TestDLL values = new TestDLL();
+        TestBytes4DLL values = new TestBytes4DLL();
         // sentinel value is initialized
         assertEq(values.size(), 0);
         // try to remove sentinel stupidly
@@ -148,14 +111,14 @@ contract Bytes4DLLLibTest is TestUtils {
         // try out different limits, even bigger than totalValues
         bound(limit, 1, 30);
         bound(totalValues, 3, 30);
-        TestDLL dll = new TestDLL();
+        TestBytes4DLL dll = new TestBytes4DLL();
         for (uint32 i = 1; i <= totalValues; i++) {
             dll.append(bytes4(i));
         }
         bulkGetAndVerifyValues(dll, totalValues, limit);
     }
 
-    function bulkGetAndVerifyValues(TestDLL dll, uint256 totalValues, uint256 limit) private view {
+    function bulkGetAndVerifyValues(TestBytes4DLL dll, uint256 totalValues, uint256 limit) private view {
         bytes4[] memory results = new bytes4[](totalValues);
         bytes4 start = SENTINEL_BYTES4;
         uint32 count = 0;

--- a/test/msca/6900/shared/libs/TestBytes32DLL.sol
+++ b/test/msca/6900/shared/libs/TestBytes32DLL.sol
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Circle Internet Group, Inc. All rights reserved.
+
+ * SPDX-License-Identifier: GPL-3.0-or-later
+
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+pragma solidity 0.8.24;
+
+import {Bytes32DLL} from "../../../../../src/msca/6900/shared/common/Structs.sol";
+import {Bytes32DLLLib} from "../../../../../src/msca/6900/shared/libs/Bytes32DLLLib.sol";
+
+contract TestBytes32DLL {
+    using Bytes32DLLLib for Bytes32DLL;
+
+    Bytes32DLL private bytes32DLL;
+
+    function append(bytes32 valueToAdd) external returns (bool) {
+        return bytes32DLL.append(valueToAdd);
+    }
+
+    function remove(bytes32 valueToRemove) external returns (bool) {
+        return bytes32DLL.remove(valueToRemove);
+    }
+
+    function size() external view returns (uint256) {
+        return bytes32DLL.size();
+    }
+
+    function contains(bytes32 value) external view returns (bool) {
+        return bytes32DLL.contains(value);
+    }
+
+    function getAll() external view returns (bytes32[] memory results) {
+        return bytes32DLL.getAll();
+    }
+
+    function getPaginated(bytes32 start, uint256 limit)
+        external
+        view
+        returns (bytes32[] memory results, bytes32 next)
+    {
+        return bytes32DLL.getPaginated(start, limit);
+    }
+
+    function getHead() external view returns (bytes32) {
+        return bytes32DLL.getHead();
+    }
+
+    function getTail() external view returns (bytes32) {
+        return bytes32DLL.getTail();
+    }
+}

--- a/test/msca/6900/shared/libs/TestBytes4DLL.sol
+++ b/test/msca/6900/shared/libs/TestBytes4DLL.sol
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Circle Internet Group, Inc. All rights reserved.
+
+ * SPDX-License-Identifier: GPL-3.0-or-later
+
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+pragma solidity 0.8.24;
+
+import {Bytes4DLL} from "../../../../../src/msca/6900/shared/common/Structs.sol";
+import {Bytes4DLLLib} from "../../../../../src/msca/6900/shared/libs/Bytes4DLLLib.sol";
+
+contract TestBytes4DLL {
+    using Bytes4DLLLib for Bytes4DLL;
+
+    Bytes4DLL private bytes4DLL;
+
+    function append(bytes4 valueToAdd) external returns (bool) {
+        return bytes4DLL.append(valueToAdd);
+    }
+
+    function remove(bytes4 valueToRemove) external returns (bool) {
+        return bytes4DLL.remove(valueToRemove);
+    }
+
+    function size() external view returns (uint256) {
+        return bytes4DLL.size();
+    }
+
+    function contains(bytes4 value) external returns (bool) {
+        return bytes4DLL.contains(value);
+    }
+
+    function getAll() external view returns (bytes4[] memory results) {
+        return bytes4DLL.getAll();
+    }
+
+    function getPaginated(bytes4 start, uint256 limit) external view returns (bytes4[] memory results, bytes4 next) {
+        return bytes4DLL.getPaginated(start, limit);
+    }
+
+    function getHead() external view returns (bytes4) {
+        return bytes4DLL.getHead();
+    }
+
+    function getTail() external view returns (bytes4) {
+        return bytes4DLL.getTail();
+    }
+}

--- a/test/msca/6900/v0.7/ChildConstructorInitializableMock.sol
+++ b/test/msca/6900/v0.7/ChildConstructorInitializableMock.sol
@@ -18,35 +18,16 @@
  */
 pragma solidity 0.8.24;
 
-/**
- * @notice Throws when the selector is not found.
- */
-error NotFoundSelector();
+import {ConstructorInitializableMock} from "./ConstructorInitializableMock.sol";
 
-/**
- * @notice Throws when authorizer is invalid.
- */
-error InvalidAuthorizer();
+contract ChildConstructorInitializableMock is ConstructorInitializableMock {
+    bool public childInitializerRan;
 
-error InvalidValidationFunctionId(uint8 functionId);
+    constructor() walletStorageInitializer {
+        childInitialize();
+    }
 
-error InvalidFunctionReference();
-
-error ItemAlreadyExists();
-
-error ItemDoesNotExist();
-
-error InvalidLimit();
-
-error InvalidExecutionFunction(bytes4 selector);
-
-error InvalidInitializationInput();
-
-error Create2FailedDeployment();
-
-error NotImplemented(bytes4 selector, uint8 functionId);
-
-error InvalidItem();
-
-// v2 NotImplemented
-error NotImplementedFunction(bytes4 selector, uint32 entityId);
+    function childInitialize() public walletStorageInitializer {
+        childInitializerRan = true;
+    }
+}

--- a/test/msca/6900/v0.7/ConstructorInitializableMock.sol
+++ b/test/msca/6900/v0.7/ConstructorInitializableMock.sol
@@ -18,35 +18,24 @@
  */
 pragma solidity 0.8.24;
 
-/**
- * @notice Throws when the selector is not found.
- */
-error NotFoundSelector();
+import {WalletStorageInitializable} from "../../../../src/msca/6900/v0.7/account/WalletStorageInitializable.sol";
+import {console} from "forge-std/src/console.sol";
 
-/**
- * @notice Throws when authorizer is invalid.
- */
-error InvalidAuthorizer();
+contract ConstructorInitializableMock is WalletStorageInitializable {
+    bool public initializerRan;
+    bool public onlyInitializingRan;
 
-error InvalidValidationFunctionId(uint8 functionId);
+    constructor() walletStorageInitializer {
+        console.logString("ConstructorInitializableMock constructor");
+        initialize();
+        initializeOnlyInitializing();
+    }
 
-error InvalidFunctionReference();
+    function initialize() public walletStorageInitializer {
+        initializerRan = true;
+    }
 
-error ItemAlreadyExists();
-
-error ItemDoesNotExist();
-
-error InvalidLimit();
-
-error InvalidExecutionFunction(bytes4 selector);
-
-error InvalidInitializationInput();
-
-error Create2FailedDeployment();
-
-error NotImplemented(bytes4 selector, uint8 functionId);
-
-error InvalidItem();
-
-// v2 NotImplemented
-error NotImplementedFunction(bytes4 selector, uint32 entityId);
+    function initializeOnlyInitializing() public onlyWalletStorageInitializing {
+        onlyInitializingRan = true;
+    }
+}

--- a/test/msca/6900/v0.7/DisableInitializingWalletStorageMock.sol
+++ b/test/msca/6900/v0.7/DisableInitializingWalletStorageMock.sol
@@ -18,35 +18,15 @@
  */
 pragma solidity 0.8.24;
 
-/**
- * @notice Throws when the selector is not found.
- */
-error NotFoundSelector();
+import {WalletStorageInitializable} from "../../../../src/msca/6900/v0.7/account/WalletStorageInitializable.sol";
+import {console} from "forge-std/src/console.sol";
 
-/**
- * @notice Throws when authorizer is invalid.
- */
-error InvalidAuthorizer();
-
-error InvalidValidationFunctionId(uint8 functionId);
-
-error InvalidFunctionReference();
-
-error ItemAlreadyExists();
-
-error ItemDoesNotExist();
-
-error InvalidLimit();
-
-error InvalidExecutionFunction(bytes4 selector);
-
-error InvalidInitializationInput();
-
-error Create2FailedDeployment();
-
-error NotImplemented(bytes4 selector, uint8 functionId);
-
-error InvalidItem();
-
-// v2 NotImplemented
-error NotImplementedFunction(bytes4 selector, uint32 entityId);
+// 1. call walletStorageInitializer before constructor, initializing is set to true
+// 2. call _disableWalletStorageInitializers in the same constructor, we can't disable initializer in the middle of
+// initialization
+contract DisableInitializingWalletStorageMock is WalletStorageInitializable {
+    constructor() walletStorageInitializer {
+        console.logString("DisableInitializingWalletStorageMock constructor");
+        _disableWalletStorageInitializers();
+    }
+}

--- a/test/msca/6900/v0.7/DisableWalletStorageInitializerMock.sol
+++ b/test/msca/6900/v0.7/DisableWalletStorageInitializerMock.sol
@@ -18,35 +18,12 @@
  */
 pragma solidity 0.8.24;
 
-/**
- * @notice Throws when the selector is not found.
- */
-error NotFoundSelector();
+import {WalletStorageInitializable} from "../../../../src/msca/6900/v0.7/account/WalletStorageInitializable.sol";
+import {console} from "forge-std/src/console.sol";
 
-/**
- * @notice Throws when authorizer is invalid.
- */
-error InvalidAuthorizer();
-
-error InvalidValidationFunctionId(uint8 functionId);
-
-error InvalidFunctionReference();
-
-error ItemAlreadyExists();
-
-error ItemDoesNotExist();
-
-error InvalidLimit();
-
-error InvalidExecutionFunction(bytes4 selector);
-
-error InvalidInitializationInput();
-
-error Create2FailedDeployment();
-
-error NotImplemented(bytes4 selector, uint8 functionId);
-
-error InvalidItem();
-
-// v2 NotImplemented
-error NotImplementedFunction(bytes4 selector, uint32 entityId);
+contract DisableWalletStorageInitializerMock is WalletStorageInitializable {
+    constructor() {
+        console.logString("DisableWalletStorageInitializerMock constructor");
+        _disableWalletStorageInitializers();
+    }
+}

--- a/test/msca/6900/v0.7/HookFunctionReferenceDLL.t.sol
+++ b/test/msca/6900/v0.7/HookFunctionReferenceDLL.t.sol
@@ -18,10 +18,11 @@
  */
 pragma solidity 0.8.24;
 
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
-import "../../../util/TestUtils.sol";
-import "./TestRepeatableFunctionReferenceDLL.sol";
-import "forge-std/src/console.sol";
+import {SENTINEL_BYTES21} from "../../../../src/common/Constants.sol";
+import {FunctionReference} from "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {TestUtils} from "../../../util/TestUtils.sol";
+import {TestRepeatableFunctionReferenceDLL} from "./TestRepeatableFunctionReferenceDLL.sol";
+import {FunctionReferenceLib} from "src/msca/6900/v0.7/libs/FunctionReferenceLib.sol";
 
 contract HookFunctionReferenceDLLTest is TestUtils {
     using FunctionReferenceLib for bytes21;

--- a/test/msca/6900/v0.7/LockWalletStorageAfterInitializationMock.sol
+++ b/test/msca/6900/v0.7/LockWalletStorageAfterInitializationMock.sol
@@ -18,35 +18,14 @@
  */
 pragma solidity 0.8.24;
 
-/**
- * @notice Throws when the selector is not found.
- */
-error NotFoundSelector();
+import {ConstructorInitializableMock} from "./ConstructorInitializableMock.sol";
+import {DisableWalletStorageInitializerMock} from "./DisableWalletStorageInitializerMock.sol";
 
-/**
- * @notice Throws when authorizer is invalid.
- */
-error InvalidAuthorizer();
-
-error InvalidValidationFunctionId(uint8 functionId);
-
-error InvalidFunctionReference();
-
-error ItemAlreadyExists();
-
-error ItemDoesNotExist();
-
-error InvalidLimit();
-
-error InvalidExecutionFunction(bytes4 selector);
-
-error InvalidInitializationInput();
-
-error Create2FailedDeployment();
-
-error NotImplemented(bytes4 selector, uint8 functionId);
-
-error InvalidItem();
-
-// v2 NotImplemented
-error NotImplementedFunction(bytes4 selector, uint32 entityId);
+// 1. call walletStorageInitializer before 1st constructor, initialization is done and initializing is set to false
+// after 1st constructor
+// 2. call _disableWalletStorageInitializers in 2nd constructor to prevent any future reinitialization
+// solhint-disable-next-line no-empty-blocks
+contract LockWalletStorageAfterInitializationMock is
+    ConstructorInitializableMock,
+    DisableWalletStorageInitializerMock
+{}

--- a/test/msca/6900/v0.7/LockedWalletStorageMock.sol
+++ b/test/msca/6900/v0.7/LockedWalletStorageMock.sol
@@ -18,35 +18,11 @@
  */
 pragma solidity 0.8.24;
 
-/**
- * @notice Throws when the selector is not found.
- */
-error NotFoundSelector();
+import {ConstructorInitializableMock} from "./ConstructorInitializableMock.sol";
+import {DisableWalletStorageInitializerMock} from "./DisableWalletStorageInitializerMock.sol";
 
-/**
- * @notice Throws when authorizer is invalid.
- */
-error InvalidAuthorizer();
-
-error InvalidValidationFunctionId(uint8 functionId);
-
-error InvalidFunctionReference();
-
-error ItemAlreadyExists();
-
-error ItemDoesNotExist();
-
-error InvalidLimit();
-
-error InvalidExecutionFunction(bytes4 selector);
-
-error InvalidInitializationInput();
-
-error Create2FailedDeployment();
-
-error NotImplemented(bytes4 selector, uint8 functionId);
-
-error InvalidItem();
-
-// v2 NotImplemented
-error NotImplementedFunction(bytes4 selector, uint32 entityId);
+// 1. call _disableWalletStorageInitializers, initialized is set to type(uint8).max to prevent any future
+// reinitialization
+// 2. call walletStorageInitializer, the locked contract should not work because it's neither initialSetup nor deploying
+// solhint-disable-next-line no-empty-blocks
+contract LockedWalletStorageMock is DisableWalletStorageInitializerMock, ConstructorInitializableMock {}

--- a/test/msca/6900/v0.7/PluginExecutor.t.sol
+++ b/test/msca/6900/v0.7/PluginExecutor.t.sol
@@ -18,26 +18,37 @@
  */
 pragma solidity 0.8.24;
 
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {PLUGIN_AUTHOR, PLUGIN_VERSION_1} from "../../../../src/common/Constants.sol";
+import {PluginMetadata} from "../../../../src/msca/6900/v0.7/common/PluginManifest.sol";
+import {Call, FunctionReference} from "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {IPlugin} from "../../../../src/msca/6900/v0.7/interfaces/IPlugin.sol";
 
-import "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
-import "../../../util/TestLiquidityPool.sol";
-import "../../../util/TestUtils.sol";
-import "./TestCircleMSCA.sol";
+import {IPluginExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
+import {IPluginManager} from "../../../../src/msca/6900/v0.7/interfaces/IPluginManager.sol";
+import {IStandardExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
+import {ISingleOwnerPlugin} from "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
+import {SingleOwnerPlugin} from "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
+import {TestLiquidityPool} from "../../../util/TestLiquidityPool.sol";
+import {TestUtils} from "../../../util/TestUtils.sol";
+import {PluginManager} from "src/msca/6900/v0.7/managers/PluginManager.sol";
 
-import "./TestCircleMSCAFactory.sol";
-import "./TestPermitAnyExternalAddressPlugin.sol";
+import {FunctionReferenceLib} from "../../../../src/msca/6900/v0.7/libs/FunctionReferenceLib.sol";
+import {IEntryPoint, TestCircleMSCA, TestCircleMSCAFactory} from "./TestCircleMSCAFactory.sol";
+import {TestPermitAnyExternalAddressPlugin} from "./TestPermitAnyExternalAddressPlugin.sol";
 
-import "./TestPermitAnyExternalAddressWithPostHookOnlyPlugin.sol";
+import {TestPermitAnyExternalAddressWithPostHookOnlyPlugin} from
+    "./TestPermitAnyExternalAddressWithPostHookOnlyPlugin.sol";
 
-import "./TestPermitAnyExternalAddressWithPreHookOnlyPlugin.sol";
-import "./TestTokenPlugin.sol";
-import "./TestTokenWithPostHookOnlyPlugin.sol";
-import "./TestTokenWithPreHookOnlyPlugin.sol";
-import "./TestUserOpValidator.sol";
-import "./TestUserOpValidatorHook.sol";
+import {TestPermitAnyExternalAddressWithPreHookOnlyPlugin} from
+    "./TestPermitAnyExternalAddressWithPreHookOnlyPlugin.sol";
+import {TestTokenPlugin} from "./TestTokenPlugin.sol";
+import {TestTokenWithPostHookOnlyPlugin} from "./TestTokenWithPostHookOnlyPlugin.sol";
+import {TestTokenWithPreHookOnlyPlugin} from "./TestTokenWithPreHookOnlyPlugin.sol";
 import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
-import "forge-std/src/console.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {console} from "forge-std/src/console.sol";
+
+/* solhint-disable max-states-count */
 
 contract PluginExecutorTest is TestUtils {
     using FunctionReferenceLib for bytes21;
@@ -67,7 +78,7 @@ contract PluginExecutorTest is TestUtils {
     PluginManager private pluginManager = new PluginManager();
     uint256 internal ownerPrivateKey;
     address private ownerAddr;
-    address payable beneficiary; // e.g. bundler
+    address payable private beneficiary; // e.g. bundler
     TestCircleMSCAFactory private factory;
     SingleOwnerPlugin private singleOwnerPlugin;
     TestCircleMSCA private msca;

--- a/test/msca/6900/v0.7/PluginManager.t.sol
+++ b/test/msca/6900/v0.7/PluginManager.t.sol
@@ -18,21 +18,29 @@
  */
 pragma solidity 0.8.24;
 
-import {EMPTY_FUNCTION_REFERENCE} from "../../../../src/common/Constants.sol";
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
-import "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
-import "../../../util/TestLiquidityPool.sol";
-import "../../../util/TestUtils.sol";
-import "./TestCircleMSCA.sol";
+import {EMPTY_FUNCTION_REFERENCE, PLUGIN_AUTHOR, PLUGIN_VERSION_1} from "../../../../src/common/Constants.sol";
+import {UnauthorizedCaller} from "../../../../src/common/Errors.sol";
+import {PluginMetadata} from "../../../../src/msca/6900/v0.7/common/PluginManifest.sol";
+import {FunctionReference} from "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {IPluginManager} from "../../../../src/msca/6900/v0.7/interfaces/IPluginManager.sol";
+import {FunctionReferenceLib} from "../../../../src/msca/6900/v0.7/libs/FunctionReferenceLib.sol";
 
-import "./TestCircleMSCAFactory.sol";
-import "./TestTokenPlugin.sol";
-import "./TestUserOpValidator.sol";
-import "./TestUserOpValidatorHook.sol";
+import {PluginManager} from "../../../../src/msca/6900/v0.7/managers/PluginManager.sol";
 
-import "./TestUserOpValidatorWithDependencyHook.sol";
+import {ISingleOwnerPlugin} from "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
+import {SingleOwnerPlugin} from "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
+import {TestLiquidityPool} from "../../../util/TestLiquidityPool.sol";
+import {TestUtils} from "../../../util/TestUtils.sol";
+import {TestCircleMSCA} from "./TestCircleMSCA.sol";
+
+import {TestCircleMSCAFactory} from "./TestCircleMSCAFactory.sol";
+import {TestTokenPlugin} from "./TestTokenPlugin.sol";
+
+import {TestUserOpValidatorWithDependencyHook} from "./TestUserOpValidatorWithDependencyHook.sol";
 import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
-import "forge-std/src/console.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {console} from "forge-std/src/console.sol";
 
 /// Tests for install/uninstall
 contract PluginManagerTest is TestUtils {
@@ -56,7 +64,7 @@ contract PluginManagerTest is TestUtils {
     PluginManager private pluginManager = new PluginManager();
     uint256 internal eoaPrivateKey;
     address private ownerAddr;
-    address payable beneficiary; // e.g. bundler
+    address payable private beneficiary; // e.g. bundler
     TestCircleMSCAFactory private factory;
     SingleOwnerPlugin private singleOwnerPlugin;
     TestCircleMSCA private msca;
@@ -120,7 +128,7 @@ contract PluginManagerTest is TestUtils {
         // install from a random address, should be rejected
         // UnauthorizedCaller is caught by the caller and converted to RuntimeValidationFailed
         vm.startPrank(address(1));
-        bytes memory revertReason = abi.encodeWithSelector(bytes4(keccak256("UnauthorizedCaller()")));
+        bytes memory revertReason = abi.encodeWithSelector(UnauthorizedCaller.selector);
         // function id from manifest
         uint8 functionId = uint8(ISingleOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF);
         vm.expectRevert(

--- a/test/msca/6900/v0.7/RepeatableFunctionReferenceDLLLib.t.sol
+++ b/test/msca/6900/v0.7/RepeatableFunctionReferenceDLLLib.t.sol
@@ -18,10 +18,12 @@
  */
 pragma solidity 0.8.24;
 
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
-import "../../../util/TestUtils.sol";
-import "./TestRepeatableFunctionReferenceDLL.sol";
-import "forge-std/src/console.sol";
+import {SENTINEL_BYTES21} from "../../../../src/common/Constants.sol";
+
+import {FunctionReference} from "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {FunctionReferenceLib} from "../../../../src/msca/6900/v0.7/libs/FunctionReferenceLib.sol";
+import {TestUtils} from "../../../util/TestUtils.sol";
+import {TestRepeatableFunctionReferenceDLL} from "./TestRepeatableFunctionReferenceDLL.sol";
 
 contract RepeatableFunctionReferenceDLLibTest is TestUtils {
     using FunctionReferenceLib for bytes21;

--- a/test/msca/6900/v0.7/SingleOwnerMSCAFactory.t.sol
+++ b/test/msca/6900/v0.7/SingleOwnerMSCAFactory.t.sol
@@ -18,16 +18,19 @@
  */
 pragma solidity 0.8.24;
 
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {InvalidInitializationInput} from "../../../../src/msca/6900/shared/common/Errors.sol";
+import {SingleOwnerMSCA} from "../../../../src/msca/6900/v0.7/account/semi/SingleOwnerMSCA.sol";
 
-import "../../../../src/msca/6900/v0.7/factories/semi/SingleOwnerMSCAFactory.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
+import {FunctionReference} from "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+
+import {SingleOwnerMSCAFactory} from "../../../../src/msca/6900/v0.7/factories/semi/SingleOwnerMSCAFactory.sol";
+import {IStandardExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
 import {PluginManager} from "../../../../src/msca/6900/v0.7/managers/PluginManager.sol";
-import "../../../util/TestLiquidityPool.sol";
-import "../../../util/TestUtils.sol";
+import {TestLiquidityPool} from "../../../util/TestLiquidityPool.sol";
+import {TestUtils} from "../../../util/TestUtils.sol";
 import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
-import "@account-abstraction/contracts/interfaces/UserOperation.sol";
-import "forge-std/src/console.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
 
 contract SingleOwnerMSCAFactoryTest is TestUtils {
     event AccountCreated(address indexed proxy, address sender, bytes32 salt);
@@ -50,7 +53,7 @@ contract SingleOwnerMSCAFactoryTest is TestUtils {
     address private ownerAddr;
     SingleOwnerMSCAFactory private factory;
     TestLiquidityPool private testLiquidityPool;
-    address payable beneficiary; // e.g. bundler
+    address payable private beneficiary; // e.g. bundler
 
     function setUp() public {
         factory = new SingleOwnerMSCAFactory(address(entryPoint), address(pluginManager));
@@ -75,7 +78,7 @@ contract SingleOwnerMSCAFactoryTest is TestUtils {
         vm.expectEmit(true, true, false, false);
         emit AccountCreated(counterfactualAddr, ownerAddr, salt);
         SingleOwnerMSCA accountCreated = factory.createAccount(ownerAddr, salt, initializingData);
-        assertEq(address(accountCreated.entryPoint()), address(entryPoint));
+        assertEq(address(accountCreated.ENTRY_POINT()), address(entryPoint));
         assertEq(accountCreated.getNativeOwner(), ownerAddr);
         // verify the address does not change
         assertEq(address(accountCreated), counterfactualAddr);

--- a/test/msca/6900/v0.7/TestPermitAnyExternalAddressPlugin.sol
+++ b/test/msca/6900/v0.7/TestPermitAnyExternalAddressPlugin.sol
@@ -18,17 +18,24 @@
  */
 pragma solidity 0.8.24;
 
+import {SIG_VALIDATION_SUCCEEDED} from "../../../../src/common/Constants.sol";
 import {PLUGIN_AUTHOR, PLUGIN_VERSION_1, SIG_VALIDATION_SUCCEEDED} from "../../../../src/common/Constants.sol";
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {NotImplemented} from "../../../../src/msca/6900/shared/common/Errors.sol";
+import {
+    ManifestAssociatedFunction,
+    ManifestAssociatedFunctionType,
+    ManifestExecutionHook,
+    ManifestFunction,
+    PluginManifest,
+    PluginMetadata
+} from "../../../../src/msca/6900/v0.7/common/PluginManifest.sol";
 
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginManager.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
+import {IPluginExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
 
-import "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
-import "../../../util/TestLiquidityPool.sol";
-import "@account-abstraction/contracts/interfaces/UserOperation.sol";
-import "forge-std/src/console.sol";
+import {BasePlugin} from "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
+import {TestLiquidityPool} from "../../../util/TestLiquidityPool.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {console} from "forge-std/src/console.sol";
 
 /**
  * @dev Plugin for tests only. This plugin permits any external contract calls.

--- a/test/msca/6900/v0.7/TestPermitAnyExternalAddressWithPostHookOnlyPlugin.sol
+++ b/test/msca/6900/v0.7/TestPermitAnyExternalAddressWithPostHookOnlyPlugin.sol
@@ -18,17 +18,25 @@
  */
 pragma solidity 0.8.24;
 
+import {SIG_VALIDATION_SUCCEEDED} from "../../../../src/common/Constants.sol";
 import {PLUGIN_AUTHOR, PLUGIN_VERSION_1, SIG_VALIDATION_SUCCEEDED} from "../../../../src/common/Constants.sol";
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {InvalidLength} from "../../../../src/common/Errors.sol";
+import {
+    ManifestAssociatedFunction,
+    ManifestAssociatedFunctionType,
+    ManifestExecutionHook,
+    ManifestFunction,
+    PluginManifest,
+    PluginMetadata
+} from "../../../../src/msca/6900/v0.7/common/PluginManifest.sol";
 
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginManager.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
+import {IPluginExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
 
-import "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
-import "../../../util/TestLiquidityPool.sol";
-import "@account-abstraction/contracts/interfaces/UserOperation.sol";
-import "forge-std/src/console.sol";
+import {NotImplemented} from "../../../../src/msca/6900/shared/common/Errors.sol";
+import {BasePlugin} from "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
+import {TestLiquidityPool} from "../../../util/TestLiquidityPool.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {console} from "forge-std/src/console.sol";
 
 /**
  * @dev Plugin for tests only. This plugin permits any external contract calls with post hook only.
@@ -99,7 +107,9 @@ contract TestPermitAnyExternalAddressWithPostHookOnlyPlugin is BasePlugin {
     function postExecutionHook(uint8 functionId, bytes calldata preExecHookData) external view override {
         console.logString("postExecutionHook data:");
         console.logBytes(preExecHookData);
-        require(preExecHookData.length == 0, "postOnlyHook should not have data");
+        if (preExecHookData.length != 0) {
+            revert InvalidLength();
+        }
         if (functionId == uint8(FunctionId.POST_EXECUTION_HOOK)) {
             return;
         } else if (functionId == uint8(FunctionId.POST_PERMITTED_CALL_EXECUTION_HOOK)) {

--- a/test/msca/6900/v0.7/TestPermitAnyExternalAddressWithPreHookOnlyPlugin.sol
+++ b/test/msca/6900/v0.7/TestPermitAnyExternalAddressWithPreHookOnlyPlugin.sol
@@ -19,16 +19,22 @@
 pragma solidity 0.8.24;
 
 import {PLUGIN_AUTHOR, PLUGIN_VERSION_1, SIG_VALIDATION_SUCCEEDED} from "../../../../src/common/Constants.sol";
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {NotImplemented} from "../../../../src/msca/6900/shared/common/Errors.sol";
+import {
+    ManifestAssociatedFunction,
+    ManifestAssociatedFunctionType,
+    ManifestExecutionHook,
+    ManifestFunction,
+    PluginManifest,
+    PluginMetadata
+} from "../../../../src/msca/6900/v0.7/common/PluginManifest.sol";
 
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginManager.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
+import {IPluginExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
 
-import "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
-import "../../../util/TestLiquidityPool.sol";
-import "@account-abstraction/contracts/interfaces/UserOperation.sol";
-import "forge-std/src/console.sol";
+import {BasePlugin} from "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
+import {TestLiquidityPool} from "../../../util/TestLiquidityPool.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {console} from "forge-std/src/console.sol";
 
 /**
  * @dev Plugin for tests only. This plugin permits any external contract calls with pre hook only.

--- a/test/msca/6900/v0.7/TestRepeatableFunctionReferenceDLL.sol
+++ b/test/msca/6900/v0.7/TestRepeatableFunctionReferenceDLL.sol
@@ -18,13 +18,14 @@
  */
 pragma solidity 0.8.24;
 
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
-import "../../../../src/msca/6900/v0.7/libs/RepeatableFunctionReferenceDLLLib.sol";
+import {FunctionReference, RepeatableBytes21DLL} from "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {RepeatableFunctionReferenceDLLLib} from
+    "../../../../src/msca/6900/v0.7/libs/RepeatableFunctionReferenceDLLLib.sol";
 
 contract TestRepeatableFunctionReferenceDLL {
     using RepeatableFunctionReferenceDLLLib for RepeatableBytes21DLL;
 
-    RepeatableBytes21DLL preValidationHooks;
+    RepeatableBytes21DLL private preValidationHooks;
 
     function appendPreValidationHook(FunctionReference memory hookToAdd) external returns (uint256) {
         return preValidationHooks.append(hookToAdd);

--- a/test/msca/6900/v0.7/TestTokenPlugin.sol
+++ b/test/msca/6900/v0.7/TestTokenPlugin.sol
@@ -19,17 +19,26 @@
 pragma solidity 0.8.24;
 
 import {PLUGIN_AUTHOR, PLUGIN_VERSION_1, SIG_VALIDATION_SUCCEEDED} from "../../../../src/common/Constants.sol";
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {NotImplemented} from "../../../../src/msca/6900/shared/common/Errors.sol";
+import {
+    ManifestAssociatedFunction,
+    ManifestAssociatedFunctionType,
+    ManifestExecutionHook,
+    ManifestExternalCallPermission,
+    ManifestFunction,
+    PluginManifest,
+    PluginMetadata,
+    SelectorPermission
+} from "src/msca/6900/v0.7/common/PluginManifest.sol";
 
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginManager.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
+import {IPluginExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
+import {IStandardExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
 
-import "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
-import "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
-import "../../../util/TestLiquidityPool.sol";
-import "@account-abstraction/contracts/interfaces/UserOperation.sol";
-import "forge-std/src/console.sol";
+import {BasePlugin} from "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
+import {ISingleOwnerPlugin} from "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
+import {TestLiquidityPool} from "../../../util/TestLiquidityPool.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {console} from "forge-std/src/console.sol";
 
 /**
  * @dev Plugin for tests only. This plugin implements everything in manifest.
@@ -57,12 +66,12 @@ contract TestTokenPlugin is BasePlugin {
     }
 
     string public constant NAME = "Test Token Plugin";
-    string constant NOT_FROZEN_PERM = "NOT_FROZEN_PERM"; // msg.sender should be able to
+    string private constant NOT_FROZEN_PERM = "NOT_FROZEN_PERM"; // msg.sender should be able to
 
     mapping(address => uint256) internal _balances;
     // use constants generated from tests here so manifest can stay pure
-    address public constant longLiquidityPoolAddr = 0x7bff7C664bFeF913FB04473CC610D41F35E2A3F9;
-    address public constant shortLiquidityPoolAddr = 0x241BB07f7eBB2CDC08Ccb8130088a8C3761cf197;
+    address public constant LONG_LIQUIDITY_POOL_ADDR = 0x7bff7C664bFeF913FB04473CC610D41F35E2A3F9;
+    address public constant SHORT_LIQUIDITY_POOL_ADDR = 0x241BB07f7eBB2CDC08Ccb8130088a8C3761cf197;
 
     /// executeFromPlugin is allowed
     /// airdrop from wallet to owner
@@ -98,10 +107,10 @@ contract TestTokenPlugin is BasePlugin {
     // mint to both liquidity pools
     function mintToken(uint256 value) external returns (bool) {
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            longLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
+            LONG_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
         );
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            shortLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
+            SHORT_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
         );
         return true;
     }
@@ -110,14 +119,14 @@ contract TestTokenPlugin is BasePlugin {
     // supply to only long liquidity pool
     function supplyLiquidity(address to, uint256 value) external {
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            longLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
+            LONG_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
         );
     }
 
     // externalFromPluginExternal is not allowed
     function supplyLiquidityBad(address to, uint256 value) external {
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            shortLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
+            SHORT_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
         );
     }
 
@@ -260,13 +269,13 @@ contract TestTokenPlugin is BasePlugin {
         manifest.permittedExternalCalls = new ManifestExternalCallPermission[](2);
         // access only mint function in shortLiquidityPool
         manifest.permittedExternalCalls[0] = ManifestExternalCallPermission({
-            externalAddress: shortLiquidityPoolAddr,
+            externalAddress: SHORT_LIQUIDITY_POOL_ADDR,
             permitAnySelector: false,
             selectors: permittedExternalCallsSelectors
         });
         // access all the functions in longLiquidityPool
         manifest.permittedExternalCalls[1] = ManifestExternalCallPermission({
-            externalAddress: longLiquidityPoolAddr,
+            externalAddress: LONG_LIQUIDITY_POOL_ADDR,
             permitAnySelector: true,
             selectors: new bytes4[](0)
         });

--- a/test/msca/6900/v0.7/TestTokenWithPostHookOnlyPlugin.sol
+++ b/test/msca/6900/v0.7/TestTokenWithPostHookOnlyPlugin.sol
@@ -19,17 +19,26 @@
 pragma solidity 0.8.24;
 
 import {PLUGIN_AUTHOR, PLUGIN_VERSION_1, SIG_VALIDATION_SUCCEEDED} from "../../../../src/common/Constants.sol";
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {InvalidLength} from "../../../../src/common/Errors.sol";
+import {NotImplemented} from "../../../../src/msca/6900/shared/common/Errors.sol";
+import {
+    ManifestAssociatedFunction,
+    ManifestAssociatedFunctionType,
+    ManifestExecutionHook,
+    ManifestExternalCallPermission,
+    ManifestFunction,
+    PluginManifest,
+    PluginMetadata,
+    SelectorPermission
+} from "../../../../src/msca/6900/v0.7/common/PluginManifest.sol";
 
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginManager.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
+import {IPluginExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
 
-import "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
-import "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
-import "../../../util/TestLiquidityPool.sol";
-import "@account-abstraction/contracts/interfaces/UserOperation.sol";
-import "forge-std/src/console.sol";
+import {BasePlugin} from "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
+import {ISingleOwnerPlugin} from "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
+import {TestLiquidityPool} from "../../../util/TestLiquidityPool.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {console} from "forge-std/src/console.sol";
 
 /**
  * @dev Plugin that only has post hooks.
@@ -46,12 +55,12 @@ contract TestTokenWithPostHookOnlyPlugin is BasePlugin {
     }
 
     string public constant NAME = "Test Token Plugin With Post Hook Only";
-    string constant NOT_FROZEN_PERM = "NOT_FROZEN_PERM"; // msg.sender should be able to
+    string private constant NOT_FROZEN_PERM = "NOT_FROZEN_PERM"; // msg.sender should be able to
 
     mapping(address => uint256) internal _balances;
     // use constants generated from tests here so manifest can stay pure
-    address public constant longLiquidityPoolAddr = 0x7bff7C664bFeF913FB04473CC610D41F35E2A3F9;
-    address public constant shortLiquidityPoolAddr = 0x241BB07f7eBB2CDC08Ccb8130088a8C3761cf197;
+    address public constant LONG_LIQUIDITY_POOL_ADDR = 0x7bff7C664bFeF913FB04473CC610D41F35E2A3F9;
+    address public constant SHORT_LIQUIDITY_POOL_ADDR = 0x241BB07f7eBB2CDC08Ccb8130088a8C3761cf197;
 
     /// executeFromPlugin is allowed
     /// airdrop from wallet to owner
@@ -87,10 +96,10 @@ contract TestTokenWithPostHookOnlyPlugin is BasePlugin {
     // mint to both liquidity pools
     function mintToken(uint256 value) external {
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            longLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
+            LONG_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
         );
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            shortLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
+            SHORT_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
         );
     }
 
@@ -98,14 +107,14 @@ contract TestTokenWithPostHookOnlyPlugin is BasePlugin {
     // supply to only long liquidity pool
     function supplyLiquidity(address to, uint256 value) external {
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            longLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
+            LONG_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
         );
     }
 
     // externalFromPluginExternal is not allowed
     function supplyLiquidityBad(address to, uint256 value) external {
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            shortLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
+            SHORT_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
         );
     }
 
@@ -161,7 +170,9 @@ contract TestTokenWithPostHookOnlyPlugin is BasePlugin {
     function postExecutionHook(uint8 functionId, bytes calldata preExecHookData) external view override {
         console.logString("postExecutionHook data:");
         console.logBytes(preExecHookData);
-        require(preExecHookData.length == 0, "postOnlyHook should not have data");
+        if (preExecHookData.length != 0) {
+            revert InvalidLength();
+        }
         if (functionId == uint8(FunctionId.POST_EXECUTION_HOOK)) {
             return;
         } else if (functionId == uint8(FunctionId.POST_EXECUTION_HOOK)) {
@@ -198,13 +209,13 @@ contract TestTokenWithPostHookOnlyPlugin is BasePlugin {
         manifest.permittedExternalCalls = new ManifestExternalCallPermission[](2);
         // access only mint function in shortLiquidityPool
         manifest.permittedExternalCalls[0] = ManifestExternalCallPermission({
-            externalAddress: shortLiquidityPoolAddr,
+            externalAddress: SHORT_LIQUIDITY_POOL_ADDR,
             permitAnySelector: false,
             selectors: permittedExternalCallsSelectors
         });
         // access all the functions in longLiquidityPool
         manifest.permittedExternalCalls[1] = ManifestExternalCallPermission({
-            externalAddress: longLiquidityPoolAddr,
+            externalAddress: LONG_LIQUIDITY_POOL_ADDR,
             permitAnySelector: true,
             selectors: new bytes4[](0)
         });

--- a/test/msca/6900/v0.7/TestTokenWithPreHookOnlyPlugin.sol
+++ b/test/msca/6900/v0.7/TestTokenWithPreHookOnlyPlugin.sol
@@ -19,17 +19,26 @@
 pragma solidity 0.8.24;
 
 import {PLUGIN_AUTHOR, PLUGIN_VERSION_1, SIG_VALIDATION_SUCCEEDED} from "../../../../src/common/Constants.sol";
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {NotImplemented} from "../../../../src/msca/6900/shared/common/Errors.sol";
+import {
+    ManifestAssociatedFunction,
+    ManifestAssociatedFunctionType,
+    ManifestExecutionHook,
+    ManifestExternalCallPermission,
+    ManifestFunction,
+    PluginManifest,
+    PluginMetadata,
+    SelectorPermission
+} from "../../../../src/msca/6900/v0.7/common/PluginManifest.sol";
 
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IPluginManager.sol";
-import "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
+import {IPluginExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IPluginExecutor.sol";
+import {IStandardExecutor} from "../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
 
-import "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
-import "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
-import "../../../util/TestLiquidityPool.sol";
-import "@account-abstraction/contracts/interfaces/UserOperation.sol";
-import "forge-std/src/console.sol";
+import {BasePlugin} from "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
+import {ISingleOwnerPlugin} from "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
+import {TestLiquidityPool} from "../../../util/TestLiquidityPool.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {console} from "forge-std/src/console.sol";
 
 /**
  * @dev Plugin for tests only with only pre hooks.
@@ -50,12 +59,12 @@ contract TestTokenWithPreHookOnlyPlugin is BasePlugin {
     }
 
     string public constant NAME = "Test Token Plugin With Pre Hook Only";
-    string constant NOT_FROZEN_PERM = "NOT_FROZEN_PERM"; // msg.sender should be able to
+    string private constant NOT_FROZEN_PERM = "NOT_FROZEN_PERM"; // msg.sender should be able to
 
     mapping(address => uint256) internal _balances;
     // use constants generated from tests here so manifest can stay pure
-    address public constant longLiquidityPoolAddr = 0x7bff7C664bFeF913FB04473CC610D41F35E2A3F9;
-    address public constant shortLiquidityPoolAddr = 0x241BB07f7eBB2CDC08Ccb8130088a8C3761cf197;
+    address public constant LONG_LIQUIDITY_POOL_ADDR = 0x7bff7C664bFeF913FB04473CC610D41F35E2A3F9;
+    address public constant SHORT_LIQUIDITY_POOL_ADDR = 0x241BB07f7eBB2CDC08Ccb8130088a8C3761cf197;
 
     /// executeFromPlugin is allowed
     /// airdrop from wallet to owner
@@ -91,10 +100,10 @@ contract TestTokenWithPreHookOnlyPlugin is BasePlugin {
     // mint to both liquidity pools
     function mintToken(uint256 value) external {
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            longLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
+            LONG_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
         );
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            shortLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
+            SHORT_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.mint, (msg.sender, value))
         );
     }
 
@@ -102,14 +111,14 @@ contract TestTokenWithPreHookOnlyPlugin is BasePlugin {
     // supply to only long liquidity pool
     function supplyLiquidity(address to, uint256 value) external {
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            longLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
+            LONG_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
         );
     }
 
     // externalFromPluginExternal is not allowed
     function supplyLiquidityBad(address to, uint256 value) external {
         IPluginExecutor(msg.sender).executeFromPluginExternal(
-            shortLiquidityPoolAddr, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
+            SHORT_LIQUIDITY_POOL_ADDR, 0, abi.encodeCall(TestLiquidityPool.supplyLiquidity, (msg.sender, to, value))
         );
     }
 
@@ -235,13 +244,13 @@ contract TestTokenWithPreHookOnlyPlugin is BasePlugin {
         manifest.permittedExternalCalls = new ManifestExternalCallPermission[](2);
         // access only mint function in shortLiquidityPool
         manifest.permittedExternalCalls[0] = ManifestExternalCallPermission({
-            externalAddress: shortLiquidityPoolAddr,
+            externalAddress: SHORT_LIQUIDITY_POOL_ADDR,
             permitAnySelector: false,
             selectors: permittedExternalCallsSelectors
         });
         // access all the functions in longLiquidityPool
         manifest.permittedExternalCalls[1] = ManifestExternalCallPermission({
-            externalAddress: longLiquidityPoolAddr,
+            externalAddress: LONG_LIQUIDITY_POOL_ADDR,
             permitAnySelector: true,
             selectors: new bytes4[](0)
         });

--- a/test/msca/6900/v0.7/TestUserOpAllPassValidator.sol
+++ b/test/msca/6900/v0.7/TestUserOpAllPassValidator.sol
@@ -18,13 +18,15 @@
  */
 pragma solidity 0.8.24;
 
+/* solhint-disable no-empty-blocks */
+
 import {ValidationData} from "../../../../src/msca/6900/shared/common/Structs.sol";
 import {PluginManifest} from "../../../../src/msca/6900/v0.7/common/PluginManifest.sol";
 import {BasePlugin} from "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
 import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
 
 contract TestUserOpAllPassValidator is BasePlugin {
-    ValidationData expectedValidationData;
+    ValidationData private expectedValidationData;
 
     constructor() {
         ValidationData memory expectToPass = ValidationData(0, 0xFFFFFFFFFFFF, address(0));

--- a/test/msca/6900/v0.7/TestUserOpValidatorHook.sol
+++ b/test/msca/6900/v0.7/TestUserOpValidatorHook.sol
@@ -23,7 +23,7 @@ import {BasePlugin} from "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol"
 import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
 
 contract TestValidatorHook is BasePlugin {
-    ValidationData expectedValidationData;
+    ValidationData private expectedValidationData;
 
     constructor(ValidationData memory _expectedValidationData) {
         expectedValidationData = _expectedValidationData;

--- a/test/msca/6900/v0.7/TestUserOpValidatorWithDependencyHook.sol
+++ b/test/msca/6900/v0.7/TestUserOpValidatorWithDependencyHook.sol
@@ -19,8 +19,14 @@
 pragma solidity 0.8.24;
 
 import {ValidationData} from "../../../../src/msca/6900/shared/common/Structs.sol";
-import "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
-import "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
+import {BasePlugin} from "../../../../src/msca/6900/v0.7/plugins/BasePlugin.sol";
+import {ISingleOwnerPlugin} from "../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
+import {
+    ManifestAssociatedFunction,
+    ManifestAssociatedFunctionType,
+    ManifestFunction,
+    PluginManifest
+} from "src/msca/6900/v0.7/common/PluginManifest.sol";
 
 /// This hook cannot be installed due to expecting being installed with hook dependencies
 contract TestUserOpValidatorWithDependencyHook is BasePlugin {

--- a/test/msca/6900/v0.7/UpgradableMSCA.t.sol
+++ b/test/msca/6900/v0.7/UpgradableMSCA.t.sol
@@ -23,7 +23,6 @@ import {EMPTY_FUNCTION_REFERENCE} from "../../../../src/common/Constants.sol";
 import {ValidationData} from "../../../../src/msca/6900/shared/common/Structs.sol";
 import {UpgradableMSCA} from "../../../../src/msca/6900/v0.7/account/UpgradableMSCA.sol";
 
-import {InvalidValidationFunctionId} from "../../../../src/msca/6900/shared/common/Errors.sol";
 import {
     PRE_HOOK_ALWAYS_DENY_FUNCTION_REFERENCE,
     RUNTIME_VALIDATION_ALWAYS_ALLOW_FUNCTION_REFERENCE
@@ -47,8 +46,6 @@ import {TestERC721} from "../../../util/TestERC721.sol";
 import {TestLiquidityPool} from "../../../util/TestLiquidityPool.sol";
 import {TestUtils} from "../../../util/TestUtils.sol";
 
-import {DefaultTokenCallbackPlugin} from
-    "../../../../src/msca/6900/v0.7/plugins/v1_0_0/utility/DefaultTokenCallbackPlugin.sol";
 import {TestValidatorHook} from "../v0.7/TestUserOpValidatorHook.sol";
 import {TestCircleMSCA} from "./TestCircleMSCA.sol";
 import {TestCircleMSCAFactory} from "./TestCircleMSCAFactory.sol";
@@ -95,7 +92,6 @@ contract UpgradableMSCATest is TestUtils {
     TestCircleMSCAFactory private factory;
     address private factoryOwner;
     SingleOwnerPlugin private singleOwnerPlugin;
-    DefaultTokenCallbackPlugin private defaultTokenCallbackPlugin;
 
     function setUp() public {
         factoryOwner = makeAddr("factoryOwner");
@@ -105,13 +101,10 @@ contract UpgradableMSCATest is TestUtils {
         testLiquidityPool = new TestLiquidityPool("getrich", "$$$");
         factory = new TestCircleMSCAFactory(factoryOwner, entryPoint, pluginManager);
         singleOwnerPlugin = new SingleOwnerPlugin();
-        defaultTokenCallbackPlugin = new DefaultTokenCallbackPlugin();
-        address[] memory _plugins = new address[](2);
+        address[] memory _plugins = new address[](1);
         _plugins[0] = address(singleOwnerPlugin);
-        _plugins[1] = address(defaultTokenCallbackPlugin);
-        bool[] memory _permissions = new bool[](2);
+        bool[] memory _permissions = new bool[](1);
         _permissions[0] = true;
-        _permissions[1] = true;
         vm.startPrank(factoryOwner);
         factory.setPlugins(_plugins, _permissions);
         vm.stopPrank();
@@ -889,10 +882,10 @@ contract UpgradableMSCATest is TestUtils {
         assertEq(testLiquidityPool.balanceOf(senderAddr), 1000000);
     }
 
-    // should not be able to receive ERC1155 token w/o token callback plugin
-    function testSendAndReceiveERC1155TokenWithoutDefaultCallbackPlugin() public {
+    // should be able to receive ERC1155 token with token callback enshrined
+    function testSendAndReceiveERC1155TokenNatively() public {
         bytes32 salt = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        (ownerAddr, eoaPrivateKey) = makeAddrAndKey("testSendAndReceiveERC1155TokenWithoutDefaultCallbackPlugin_sender");
+        (ownerAddr, eoaPrivateKey) = makeAddrAndKey("testSendAndReceiveERC1155TokenNatively_sender");
         address[] memory plugins = new address[](1);
         bytes32[] memory manifestHashes = new bytes32[](1);
         bytes[] memory pluginInstallData = new bytes[](1);
@@ -903,14 +896,14 @@ contract UpgradableMSCATest is TestUtils {
         factory.createAccount(ownerAddr, salt, initializingData);
         (address senderAddr,) = factory.getAddress(ownerAddr, salt, initializingData);
         vm.deal(senderAddr, 1 ether);
-        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
         testERC1155.mint(senderAddr, 0, 2, "");
+        assertEq(testERC1155.balanceOf(senderAddr, 0), 2);
     }
 
-    // should not be able to receive ERC721 token w/o token callback plugin
-    function testSendAndReceiveERC721TokenWithoutDefaultCallbackPlugin() public {
+    // should not be able to receive ERC721 token with token callback enshrined
+    function testSendAndReceiveERC721TokenNatively() public {
         bytes32 salt = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        (ownerAddr, eoaPrivateKey) = makeAddrAndKey("testSendAndReceiveERC721TokenWithoutDefaultCallbackPlugin_sender");
+        (ownerAddr, eoaPrivateKey) = makeAddrAndKey("testSendAndReceiveERC721TokenNatively_sender");
         address[] memory plugins = new address[](1);
         bytes32[] memory manifestHashes = new bytes32[](1);
         bytes[] memory pluginInstallData = new bytes[](1);
@@ -921,24 +914,20 @@ contract UpgradableMSCATest is TestUtils {
         factory.createAccount(ownerAddr, salt, initializingData);
         (address senderAddr,) = factory.getAddress(ownerAddr, salt, initializingData);
         vm.deal(senderAddr, 1 ether);
-        // we do the runtime validation now first, so it would not even pass that due to missing of onERC721Received
-        vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("InvalidValidationFunctionId(uint8)")), uint8(0)));
         testERC721.safeMint(senderAddr, 0);
+        assertEq(testERC721.balanceOf(senderAddr), 1);
     }
 
-    // should be able to send/receive ERC1155 token with token callback plugin
-    function testSendAndReceiveERC1155TokenWithDefaultCallbackPlugin() public {
+    // should be able to send/receive ERC1155 token with token callback handler
+    function testSendAndReceiveERC1155TokenWithDefaultCallbackHandler() public {
         bytes32 salt = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        (ownerAddr, eoaPrivateKey) = makeAddrAndKey("testSendAndReceiveERC1155TokenWithDefaultCallbackPlugin_sender");
-        address[] memory plugins = new address[](2);
-        bytes32[] memory manifestHashes = new bytes32[](2);
-        bytes[] memory pluginInstallData = new bytes[](2);
-        plugins[0] = address(defaultTokenCallbackPlugin);
-        manifestHashes[0] = keccak256(abi.encode(defaultTokenCallbackPlugin.pluginManifest()));
-        pluginInstallData[0] = "";
-        plugins[1] = address(singleOwnerPlugin);
-        manifestHashes[1] = keccak256(abi.encode(singleOwnerPlugin.pluginManifest()));
-        pluginInstallData[1] = abi.encode(ownerAddr);
+        (ownerAddr, eoaPrivateKey) = makeAddrAndKey("testSendAndReceiveERC1155TokenWithDefaultCallbackHandler_sender");
+        address[] memory plugins = new address[](1);
+        bytes32[] memory manifestHashes = new bytes32[](1);
+        bytes[] memory pluginInstallData = new bytes[](1);
+        plugins[0] = address(singleOwnerPlugin);
+        manifestHashes[0] = keccak256(abi.encode(singleOwnerPlugin.pluginManifest()));
+        pluginInstallData[0] = abi.encode(ownerAddr);
         bytes memory initializingData = abi.encode(plugins, manifestHashes, pluginInstallData);
         factory.createAccount(ownerAddr, salt, initializingData);
         (address senderAddr,) = factory.getAddress(ownerAddr, salt, initializingData);
@@ -986,19 +975,16 @@ contract UpgradableMSCATest is TestUtils {
         assertEq(testERC1155.balanceOf(senderAddr, 0), 1);
     }
 
-    // should be able to send/receive ERC721 token with token callback plugin
-    function testSendAndReceiveERC721TokenWithDefaultCallbackPlugin() public {
+    // should be able to send/receive ERC721 token with token callback handler
+    function testSendAndReceiveERC721TokenWithDefaultCallbackHandler() public {
         bytes32 salt = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        (ownerAddr, eoaPrivateKey) = makeAddrAndKey("testSendAndReceiveERC721TokenWithDefaultCallbackPlugin_sender");
-        address[] memory plugins = new address[](2);
-        bytes32[] memory manifestHashes = new bytes32[](2);
-        bytes[] memory pluginInstallData = new bytes[](2);
-        plugins[0] = address(defaultTokenCallbackPlugin);
-        manifestHashes[0] = keccak256(abi.encode(defaultTokenCallbackPlugin.pluginManifest()));
-        pluginInstallData[0] = "";
-        plugins[1] = address(singleOwnerPlugin);
-        manifestHashes[1] = keccak256(abi.encode(singleOwnerPlugin.pluginManifest()));
-        pluginInstallData[1] = abi.encode(ownerAddr);
+        (ownerAddr, eoaPrivateKey) = makeAddrAndKey("testSendAndReceiveERC721TokenWithDefaultCallbackHandler_sender");
+        address[] memory plugins = new address[](1);
+        bytes32[] memory manifestHashes = new bytes32[](1);
+        bytes[] memory pluginInstallData = new bytes[](1);
+        plugins[0] = address(singleOwnerPlugin);
+        manifestHashes[0] = keccak256(abi.encode(singleOwnerPlugin.pluginManifest()));
+        pluginInstallData[0] = abi.encode(ownerAddr);
         bytes memory initializingData = abi.encode(plugins, manifestHashes, pluginInstallData);
         factory.createAccount(ownerAddr, salt, initializingData);
         (address senderAddr,) = factory.getAddress(ownerAddr, salt, initializingData);

--- a/test/msca/6900/v0.7/UpgradableMSCAFactory.t.sol
+++ b/test/msca/6900/v0.7/UpgradableMSCAFactory.t.sol
@@ -117,7 +117,7 @@ contract UpgradableMSCAFactoryTest is TestUtils {
         vm.expectEmit(true, true, false, false);
         emit AccountCreated(counterfactualAddr, addressToBytes32(ownerAddr), salt);
         UpgradableMSCA accountCreated = factory.createAccount(addressToBytes32(ownerAddr), salt, initializingData);
-        assertEq(address(accountCreated.entryPoint()), address(entryPoint));
+        assertEq(address(accountCreated.ENTRY_POINT()), address(entryPoint));
         assertEq(singleOwnerPlugin.getOwnerOf(address(accountCreated)), ownerAddr);
         // verify the address does not change
         assertEq(address(accountCreated), counterfactualAddr);

--- a/test/msca/6900/v0.7/WalletStorageInitializable.t.sol
+++ b/test/msca/6900/v0.7/WalletStorageInitializable.t.sol
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 Circle Internet Group, Inc. All rights reserved.
+
+ * SPDX-License-Identifier: GPL-3.0-or-later
+
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+pragma solidity 0.8.24;
+
+import {TestUtils} from "../../../util/TestUtils.sol";
+import {ChildConstructorInitializableMock} from "./ChildConstructorInitializableMock.sol";
+import {ConstructorInitializableMock} from "./ConstructorInitializableMock.sol";
+import {DisableInitializingWalletStorageMock} from "./DisableInitializingWalletStorageMock.sol";
+import {LockWalletStorageAfterInitializationMock} from "./LockWalletStorageAfterInitializationMock.sol";
+import {LockedWalletStorageMock} from "./LockedWalletStorageMock.sol";
+
+import {WalletStorageInitializableMock} from "./WalletStorageInitializableMock.sol";
+
+contract WalletStorageInitializableTest is TestUtils {
+    event WalletStorageInitialized();
+
+    error WalletStorageIsInitialized();
+    error WalletStorageIsNotInitializing();
+    error WalletStorageIsInitializing();
+
+    function testBeforeInitialize() public {
+        WalletStorageInitializableMock wallet = new WalletStorageInitializableMock();
+        assertFalse(wallet.initializerRan());
+        assertFalse(wallet.isInitializing());
+
+        // cannot call initializeOnlyInitializing function outside the scope of an initializable function
+        vm.expectRevert(WalletStorageIsNotInitializing.selector);
+        wallet.initializeOnlyInitializing();
+    }
+
+    function testAfterInitialize() public {
+        WalletStorageInitializableMock wallet = new WalletStorageInitializableMock();
+        wallet.initialize();
+        assertTrue(wallet.initializerRan());
+        assertFalse(wallet.isInitializing());
+        vm.expectRevert(WalletStorageIsInitialized.selector);
+        wallet.initialize();
+
+        // cannot call initializeOnlyInitializing function outside the scope of an initializable function
+        vm.expectRevert(WalletStorageIsNotInitializing.selector);
+        wallet.initializeOnlyInitializing();
+    }
+
+    function testNestedUnderAnInitializer() public {
+        WalletStorageInitializableMock wallet = new WalletStorageInitializableMock();
+        vm.expectRevert(WalletStorageIsInitialized.selector);
+        wallet.initializerNested();
+
+        wallet.onlyInitializingNested();
+        assertTrue(wallet.onlyInitializingRan());
+
+        // cannot call initializeOnlyInitializing function outside the scope of an initializable function
+        vm.expectRevert(WalletStorageIsNotInitializing.selector);
+        wallet.initializeOnlyInitializing();
+    }
+
+    function testNestedInitializerCanRunDuringConstruction() public {
+        ConstructorInitializableMock mock = new ConstructorInitializableMock();
+        assertTrue(mock.initializerRan());
+        assertTrue(mock.onlyInitializingRan());
+    }
+
+    function testMultipleConstructorLevelsCanBeInitializers() public {
+        ChildConstructorInitializableMock mock = new ChildConstructorInitializableMock();
+        assertTrue(mock.initializerRan());
+        assertTrue(mock.onlyInitializingRan());
+        assertTrue(mock.childInitializerRan());
+    }
+
+    function testInitLockedWalletStorage() public {
+        // the wallet is disabled/locked from initializing,
+        // so it should not be able to initialize in walletStorageInitializer
+        vm.expectRevert(WalletStorageIsInitialized.selector);
+        new LockedWalletStorageMock();
+    }
+
+    function testDisableInitializationInMiddleOfInitializing() public {
+        // the wallet is the middle of initializing
+        // so it should not be able to disable the process
+        vm.expectRevert(WalletStorageIsInitializing.selector);
+        new DisableInitializingWalletStorageMock();
+    }
+
+    function testDisableInitializationAfterInit() public {
+        vm.expectEmit(true, true, true, true);
+        emit WalletStorageInitialized();
+        new LockWalletStorageAfterInitializationMock();
+    }
+}

--- a/test/msca/6900/v0.7/WalletStorageInitializableMock.sol
+++ b/test/msca/6900/v0.7/WalletStorageInitializableMock.sol
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Circle Internet Group, Inc. All rights reserved.
+
+ * SPDX-License-Identifier: GPL-3.0-or-later
+
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+pragma solidity 0.8.24;
+
+import {WalletStorageInitializable} from "../../../../src/msca/6900/v0.7/account/WalletStorageInitializable.sol";
+import {WalletStorageV1Lib} from "../../../../src/msca/6900/v0.7/libs/WalletStorageV1Lib.sol";
+
+/**
+ * @title InitializableMock, forked from OpenZeppelin
+ * @dev This contract is a mock to test WalletStorageInitializable functionality. It is not intended for production.
+ *      There are some use cases we don't use in our protocol, such as the contract is initialized at version 1 (no
+ * reininitialization) and the current contract is just being deployed,
+ *      but we still want to test them.
+ */
+contract WalletStorageInitializableMock is WalletStorageInitializable {
+    bool public initializerRan;
+    bool public onlyInitializingRan;
+
+    function isInitializing() public view returns (bool) {
+        return WalletStorageV1Lib.getLayout().initializing;
+    }
+
+    function initialize() public walletStorageInitializer {
+        initializerRan = true;
+    }
+
+    function initializeOnlyInitializing() public onlyWalletStorageInitializing {
+        onlyInitializingRan = true;
+    }
+
+    function initializerNested() public walletStorageInitializer {
+        initialize();
+    }
+
+    function onlyInitializingNested() public walletStorageInitializer {
+        initializeOnlyInitializing();
+    }
+}

--- a/test/msca/6900/v0.7/WalletStorageV1Lib.t.sol
+++ b/test/msca/6900/v0.7/WalletStorageV1Lib.t.sol
@@ -19,14 +19,16 @@
 pragma solidity 0.8.24;
 
 import {SENTINEL_BYTES21} from "../../../../src/common/Constants.sol";
-import "../../../../src/msca/6900/v0.7/account/UpgradableMSCA.sol";
-import "../../../../src/msca/6900/v0.7/common/Structs.sol";
-import "../../../util/TestUtils.sol";
-import "./TestCircleMSCA.sol";
-import "./TestUserOpValidator.sol";
-import "./TestUserOpValidatorHook.sol";
+import {FunctionReference, RepeatableBytes21DLL} from "../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {FunctionReferenceLib} from "../../../../src/msca/6900/v0.7/libs/FunctionReferenceLib.sol";
+import {RepeatableFunctionReferenceDLLLib} from
+    "../../../../src/msca/6900/v0.7/libs/RepeatableFunctionReferenceDLLLib.sol";
+
+import {TestUtils} from "../../../util/TestUtils.sol";
+import {TestCircleMSCA} from "./TestCircleMSCA.sol";
 import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
-import "forge-std/src/console.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {PluginManager} from "src/msca/6900/v0.7/managers/PluginManager.sol";
 
 contract WalletStorageV1LibTest is TestUtils {
     using RepeatableFunctionReferenceDLLLib for RepeatableBytes21DLL;

--- a/test/msca/6900/v0.7/plugins/AddressBookPluginWithFullMSCA.t.sol
+++ b/test/msca/6900/v0.7/plugins/AddressBookPluginWithFullMSCA.t.sol
@@ -18,20 +18,34 @@
  */
 pragma solidity 0.8.24;
 
-import "../../../../../src/msca/6900/v0.7/account/BaseMSCA.sol";
-import {PRE_HOOK_ALWAYS_DENY_FUNCTION_REFERENCE} from "../../../../../src/msca/6900/v0.7/common/Constants.sol";
-import "../../../../../src/msca/6900/v0.7/common/Structs.sol";
-import "../../../../../src/msca/6900/v0.7/factories/UpgradableMSCAFactory.sol";
-import "../../../../../src/msca/6900/v0.7/libs/FunctionReferenceLib.sol";
-import "../../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
+import {UnauthorizedCaller} from "../../../../../src/common/Errors.sol";
+import {BaseMSCA} from "../../../../../src/msca/6900/v0.7/account/BaseMSCA.sol";
 
-import "../../../../../src/msca/6900/v0.7/plugins/v1_0_0/addressbook/AddressBookPlugin.sol";
-import "../../../../../src/msca/6900/v0.7/plugins/v1_0_0/addressbook/IAddressBookPlugin.sol";
-import "../../../../../src/utils/ExecutionUtils.sol";
-import "../../../../util/TestLiquidityPool.sol";
-import "../../../../util/TestUtils.sol";
+import {UpgradableMSCA} from "../../../../../src/msca/6900/v0.7/account/UpgradableMSCA.sol";
+import {PRE_HOOK_ALWAYS_DENY_FUNCTION_REFERENCE} from "../../../../../src/msca/6900/v0.7/common/Constants.sol";
+import {
+    Call,
+    ExecutionFunctionConfig,
+    ExecutionHooks,
+    FunctionReference
+} from "../../../../../src/msca/6900/v0.7/common/Structs.sol";
+import {UpgradableMSCAFactory} from "../../../../../src/msca/6900/v0.7/factories/UpgradableMSCAFactory.sol";
+import {IStandardExecutor} from "../../../../../src/msca/6900/v0.7/interfaces/IStandardExecutor.sol";
+import {FunctionReferenceLib} from "../../../../../src/msca/6900/v0.7/libs/FunctionReferenceLib.sol";
+import {PluginManager} from "../../../../../src/msca/6900/v0.7/managers/PluginManager.sol";
+import {ISingleOwnerPlugin} from "../../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/ISingleOwnerPlugin.sol";
+import {SingleOwnerPlugin} from "../../../../../src/msca/6900/v0.7/plugins/v1_0_0/acl/SingleOwnerPlugin.sol";
+import {IPluginManager} from "src/msca/6900/v0.7/interfaces/IPluginManager.sol";
+
+import {AddressBookPlugin} from "../../../../../src/msca/6900/v0.7/plugins/v1_0_0/addressbook/AddressBookPlugin.sol";
+import {IAddressBookPlugin} from "../../../../../src/msca/6900/v0.7/plugins/v1_0_0/addressbook/IAddressBookPlugin.sol";
+import {ExecutionUtils} from "../../../../../src/utils/ExecutionUtils.sol";
+import {TestLiquidityPool} from "../../../../util/TestLiquidityPool.sol";
+import {TestUtils} from "../../../../util/TestUtils.sol";
 import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
-import "forge-std/src/console.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {console} from "forge-std/src/console.sol";
 
 // some common test cases related to plugin itself is covered in AddressBookPluginWithSemiMSCATest
 contract AddressBookPluginWithFullMSCATest is TestUtils {
@@ -56,14 +70,14 @@ contract AddressBookPluginWithFullMSCATest is TestUtils {
     PluginManager private pluginManager = new PluginManager();
     uint256 internal eoaPrivateKey;
     address private ownerAddr;
-    address payable beneficiary; // e.g. bundler
+    address payable private beneficiary; // e.g. bundler
     UpgradableMSCAFactory private factory;
     AddressBookPlugin private addressBookPlugin;
     TestLiquidityPool private testLiquidityPool;
     address private addressBookPluginAddr;
     UpgradableMSCA private msca;
     address private mscaAddr;
-    bytes32 addressBookPluginManifest;
+    bytes32 private addressBookPluginManifest;
     SingleOwnerPlugin private singleOwnerPlugin;
     address private factoryOwner;
 
@@ -1044,7 +1058,7 @@ contract AddressBookPluginWithFullMSCATest is TestUtils {
         msca = factory.createAccount(addressToBytes32(ownerAddr), bytes32(0), _initializingData);
         console.log("address(msca) -> %s", address(msca));
         (bool sent,) = address(msca).call{value: 10e18}("");
-        require(sent, "Failed to send Ether");
+        assertTrue(sent);
         FunctionReference[] memory dependencies = new FunctionReference[](2);
         dependencies[0] = FunctionReference(
             address(singleOwnerPlugin), uint8(ISingleOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)

--- a/test/msca/6900/v0.7/plugins/ColdStorageAddressBookPluginWithFullMSCA.t.sol
+++ b/test/msca/6900/v0.7/plugins/ColdStorageAddressBookPluginWithFullMSCA.t.sol
@@ -19,7 +19,7 @@
 pragma solidity 0.8.24;
 
 import {EMPTY_FUNCTION_REFERENCE} from "../../../../../src/common/Constants.sol";
-import {UnauthorizedCaller} from "../../../../../src/msca/6900/shared/common/Errors.sol";
+import {UnauthorizedCaller} from "../../../../../src/common/Errors.sol";
 import {BaseMSCA} from "../../../../../src/msca/6900/v0.7/account/BaseMSCA.sol";
 import {UpgradableMSCA} from "../../../../../src/msca/6900/v0.7/account/UpgradableMSCA.sol";
 

--- a/test/msca/6900/v0.7/plugins/ColdStorageAddressBookPluginWithSemiMSCA.t.sol
+++ b/test/msca/6900/v0.7/plugins/ColdStorageAddressBookPluginWithSemiMSCA.t.sol
@@ -19,7 +19,8 @@
 pragma solidity 0.8.24;
 
 import {EMPTY_FUNCTION_REFERENCE, PLUGIN_AUTHOR, PLUGIN_VERSION_1} from "../../../../../src/common/Constants.sol";
-import {NotImplemented, UnauthorizedCaller, Unsupported} from "../../../../../src/msca/6900/shared/common/Errors.sol";
+import {UnauthorizedCaller, Unsupported} from "../../../../../src/common/Errors.sol";
+import {NotImplemented} from "../../../../../src/msca/6900/shared/common/Errors.sol";
 import {BaseMSCA} from "../../../../../src/msca/6900/v0.7/account/BaseMSCA.sol";
 import {SingleOwnerMSCA} from "../../../../../src/msca/6900/v0.7/account/semi/SingleOwnerMSCA.sol";
 


### PR DESCRIPTION
## Summary
This PR addresses the linting warnings and corrects the logic in `WalletStorageInitializable`.

## Detail
### Changeset
* Resolve all warnings (thanks to Ashutosh!)
* Correct the logic in the unused code within `WalletStorageInitializable`
* Eliminate redundant calls in `SingleOwnerMSCA` constructor
* Add a sanity check `!= address(0)` in `SingleOwnerMSCA`

### Checklist
- [x] Did you add new tests and confirm all tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `docs` folder)
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint`) and fix any issues?
- [x] Did you run formatter (`yarn format:check`) and fix any issues (`yarn format:write`)?

## Testing
* No new tests have been added for style changes.
* New tests have been included for the fixes:
  * For the `walletStorageInitializer` fix, I have forked the OZ JavaScript tests and rewritten them using Foundry.
  * The remaining two changes are already covered by existing tests (we don't allow installing `address(0)` and `testInitializeSingleOwnerMSCAWithRuntimeValidation`).

## Documentation
n/a
