### PR TITLE
chore: revert the check to allow arbitrary calldata length use cases

### DIFF
--- a/src/msca/6900/v0.7/managers/PluginExecutor.sol
+++ b/src/msca/6900/v0.7/managers/PluginExecutor.sol
@@ -77,9 +77,6 @@ library PluginExecutor {
         internal
         returns (bytes memory)
     {
-        if (data.length < 4) {
-            revert NotFoundSelector();
-        }
         if (target == address(this) || ERC165Checker.supportsInterface(target, type(IPlugin).interfaceId)) {
             revert ExecuteFromPluginToExternalNotPermitted();
         }

--- a/test/msca/6900/v0.7/TestTokenPlugin.sol
+++ b/test/msca/6900/v0.7/TestTokenPlugin.sol
@@ -115,8 +115,8 @@ contract TestTokenPlugin is BasePlugin {
         return true;
     }
 
-    function callExecuteFromPluginExternal(bytes calldata data) external returns (bool) {
-        IPluginExecutor(msg.sender).executeFromPluginExternal(LONG_LIQUIDITY_POOL_ADDR, 0, data);
+    function callExecuteFromPluginExternal(uint256 value, bytes calldata data) external returns (bool) {
+        IPluginExecutor(msg.sender).executeFromPluginExternal(LONG_LIQUIDITY_POOL_ADDR, value, data);
         return true;
     }
 
@@ -517,6 +517,7 @@ contract TestTokenPlugin is BasePlugin {
             })
         });
 
+        manifest.canSpendNativeToken = true;
         manifest.dependencyInterfaceIds = new bytes4[](1);
         manifest.dependencyInterfaceIds[0] = type(ISingleOwnerPlugin).interfaceId;
         return manifest;


### PR DESCRIPTION
## Summary
The calling contract should be responsible for checking the calldata length when they call `executeFromPluginToExternal`.

## Detail
### Changeset
* reverted the change and added a new test.

### Checklist
- [x] Did you add new tests and confirm all tests pass? (`yarn test`)
- [ ] Did you update relevant docs? (docs are found in the `docs` folder)
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [ ] If you have a breaking change, is it [correctly reflected in your commit message](https://www.conventionalcommits.org/en/v1.0.0/#examples)? (e.g. `feat!: breaking change`)
- [x] Did you run lint (`yarn lint`) and fix any issues?
- [x] Did you run formatter (`yarn format:check`) and fix any issues (`yarn format:write`)?

## Testing
* added a test case to verify native token transfer is allowed

## Documentation
n/a
