### PR TITLE
chore: add missing copyright header

### DIFF
--- a/script/test/checkCoverage.js
+++ b/script/test/checkCoverage.js
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2025 Circle Internet Group, Inc. All rights reserved.
+
+ * SPDX-License-Identifier: GPL-3.0-or-later
+
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 const fs = require('fs');
 
 const COVERAGE_TABLE_HEADER = "| File                                                                           | % Lines            | % Statements       | % Branches       | % Funcs          |";


### PR DESCRIPTION
## Summary

Add missing copyright header to the `checkCoverage.js` file.
