### PR TITLE
feat(6900/v0.8): add address book module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build
 /cache_forge
 /out
 .gas-snapshot
+foundry.lock
 
 # Python environment file
 /venv

--- a/src/libs/RecipientAddressLib.sol
+++ b/src/libs/RecipientAddressLib.sol
@@ -74,6 +74,19 @@ library RecipientAddressLib {
         return address(0);
     }
 
+    function containsERC20Methods(bytes memory data) internal pure returns (bool) {
+        bytes4 selector = bytes4(data);
+        if (
+            selector == IERC20.transfer.selector || selector == IERC20.approve.selector
+                || selector == ERC20_INCREASE_ALLOWANCE || selector == ERC20_DECREASE_ALLOWANCE
+        ) {
+            return data.length >= TRANSFER_OR_APPROVE_MIN_LEN;
+        } else if (selector == IERC20.transferFrom.selector) {
+            return data.length >= TRANSFER_FROM_MIN_LEN;
+        }
+        return false;
+    }
+
     /// @notice Decode the recipient of a token.
     /// @dev This only supports the following **standard** ERC1155 functions:
     /// - setApprovalForAll(address,bool)
@@ -113,6 +126,18 @@ library RecipientAddressLib {
         return address(0);
     }
 
+    function containsERC1155Methods(bytes memory data) internal pure returns (bool) {
+        bytes4 selector = bytes4(data);
+        if (selector == IERC1155.setApprovalForAll.selector) {
+            return data.length >= TRANSFER_OR_APPROVE_MIN_LEN;
+        } else if (selector == IERC1155.safeTransferFrom.selector) {
+            return data.length >= TRANSFER_FROM_WITH_BYTES_MIN_LEN;
+        } else if (selector == IERC1155.safeBatchTransferFrom.selector) {
+            return data.length >= BATCH_TRANSFER_FROM_WITH_BYTES_MIN_LEN;
+        }
+        return false;
+    }
+
     /// @notice Decode the recipient of a token.
     /// @dev This only supports the following **standard** ERC721 functions:
     /// - safeTransferFrom(address,address,uint256)
@@ -149,6 +174,18 @@ library RecipientAddressLib {
             return getRecipient(data, TRANSFER_FROM_RECIPIENT_OFFSET);
         }
         return address(0);
+    }
+
+    function containsERC721Methods(bytes memory data) internal pure returns (bool) {
+        bytes4 selector = bytes4(data);
+        if (selector == IERC721.setApprovalForAll.selector || selector == IERC721.approve.selector) {
+            return data.length >= TRANSFER_OR_APPROVE_MIN_LEN;
+        } else if (selector == ERC721_SAFE_TRANSFER_FROM || selector == IERC721.transferFrom.selector) {
+            return data.length >= TRANSFER_FROM_MIN_LEN;
+        } else if (selector == ERC721_SAFE_TRANSFER_FROM_WITH_BYTES) {
+            return data.length >= TRANSFER_FROM_WITHOUT_AMOUNT_WITH_BYTES_MIN_LEN;
+        }
+        return false;
     }
 
     /// @dev The caller must skip over the initial length prefix.

--- a/src/msca/6900/shared/common/Errors.sol
+++ b/src/msca/6900/shared/common/Errors.sol
@@ -52,3 +52,5 @@ error InvalidItem();
 error NotImplementedFunction(bytes4 selector, uint32 entityId);
 
 error SignatureInflation();
+
+error UnexpectedDataPassed();

--- a/src/msca/6900/v0.8/modules/BaseModule.sol
+++ b/src/msca/6900/v0.8/modules/BaseModule.sol
@@ -18,7 +18,9 @@
  */
 pragma solidity 0.8.24;
 
+import {UnexpectedDataPassed} from "../../shared/common/Errors.sol";
 import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
+import {IAccountExecute} from "@eth-infinitism/account-abstraction/interfaces/IAccountExecute.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
@@ -27,6 +29,13 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  * support open-ended execution.
  */
 abstract contract BaseModule is IModule, ERC165 {
+    modifier assertNoData(bytes calldata data) {
+        if (data.length > 0) {
+            revert UnexpectedDataPassed();
+        }
+        _;
+    }
+
     /// @dev Returns true if this contract implements the interface defined by
     /// `interfaceId`. See the corresponding
     /// https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
@@ -40,5 +49,33 @@ abstract contract BaseModule is IModule, ERC165 {
     /// @return True if the contract supports `interfaceId`.
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
         return interfaceId == type(IModule).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /// @dev help method that returns extracted selector and calldata. If selector is executeUserOp, return the
+    /// selector and calldata of the inner call. This is unique for both validation and execution phases.
+    /// During validation phase, the `data` parameter is the uo's calldata.
+    function _validationPhaseGetSelectorAndCalldata(bytes calldata data) internal pure returns (bytes4, bytes memory) {
+        bytes4 selector = bytes4(data[:4]);
+        if (selector == IAccountExecute.executeUserOp.selector) {
+            // Copy the data to memory
+            bytes memory finalCalldata = data;
+
+            // Bytes arr representation: [bytes32(len), bytes4(executeUserOp.selector), bytes4(actualSelector),
+            // bytes(actualCallData)]
+            assembly ("memory-safe") {
+                // Copy actualSelector into a new var
+                selector := shl(224, mload(add(finalCalldata, 8)))
+
+                let len := mload(finalCalldata)
+
+                // Move the finalCalldata pointer by 8
+                finalCalldata := add(finalCalldata, 8)
+
+                // Shorten bytes array by 8 by: store length - 8 into the new pointer location
+                mstore(finalCalldata, sub(len, 8))
+            }
+            return (selector, finalCalldata);
+        }
+        return (selector, data[4:]);
     }
 }

--- a/src/msca/6900/v0.8/modules/addressbook/AddressBookModule.sol
+++ b/src/msca/6900/v0.8/modules/addressbook/AddressBookModule.sol
@@ -1,0 +1,299 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+pragma solidity 0.8.24;
+
+import {SIG_VALIDATION_SUCCEEDED} from "../../../../../common/Constants.sol";
+
+import {Unsupported} from "../../../../../common/Errors.sol";
+import {CastLib} from "../../../../../libs/CastLib.sol";
+import {RecipientAddressLib} from "../../../../../libs/RecipientAddressLib.sol";
+
+import {Call} from "../../common/Structs.sol";
+
+import {BaseModule} from "../BaseModule.sol";
+import {IAddressBookModule} from "./IAddressBookModule.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {
+    ExecutionManifest,
+    ManifestExecutionFunction
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+
+import {IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
+
+import {
+    AssociatedLinkedListSet,
+    AssociatedLinkedListSetLib
+} from "@modular-account-libs/libraries/AssociatedLinkedListSetLib.sol";
+import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
+
+/**
+ * @dev This module serves as an ERC-6900 hook to validate recipients of token assets in an opinionated fashion;
+ *      - For erc20 tokens only the `transfer(address,uint256)`, `transferFrom(address,address,uint256)`,
+ * `approve(address,uint256)`, `increaseAllowance(address,uint256)`, `decreaseAllowance(address,uint256)` methods are
+ * checked.
+ *      - For erc1155 tokens only the `setApprovalForAll(address,bool)`,
+ * `safeTransferFrom(address,address,uint256,uint256,bytes)`,
+ * `safeBatchTransferFrom(address,address,uint256[],uint256[],bytes)` methods are checked.
+ *      - For erc721 tokens only the `safeTransferFrom(address,address,uint256)`,
+ * `safeTransferFrom(address,address,uint256,bytes)`, `transferFrom(address,address,uint256)`,
+ * `approve(address,uint256)`, `setApprovalForAll(address,bool)` methods are checked.
+ *
+ *      If a call contains data and value is 0 and selector is not checked, the transaction will be allowed to continue.
+ *      This module can be paired with another validation hook module to force that interactions with token contracts
+ * only use selectors that are checked in this hook module.
+ *
+ *      Design:
+ *      1. For token transfers, verify support for the function selector; if unsupported, allow bypass. This
+ * validation is bypassed for native transfers.
+ *      2. Extract the recipient's address from the transaction's calldata for token transfers, or from the target for
+ * native transfers.
+ *      3. If the recipient's address is not specified (== address(0)) within the calldata, allow bypass.
+ *      4. Given a recipient is successfully parsed out of calldata intended for token contract or parsed out of native
+ * transfer, validate the recipient against the on-chain address book; validate the target if value > 0 && recipient !=
+ * target; unauthorized addresses result in transaction rejection.
+ *      5. If the recipient is authorized, proceed with the transaction.
+ *
+ *      Misc:
+ *      - hook entityId is ignored in this module, so this hook will treat every call from the 6900 account the same
+ * way.
+ */
+contract AddressBookModule is IAddressBookModule, BaseModule {
+    using AssociatedLinkedListSetLib for AssociatedLinkedListSet;
+    using RecipientAddressLib for bytes;
+
+    // act as a safety mechanism if a module is blocking uninstallation
+    uint16 internal constant _MAX_RECIPIENTS_TO_DELETE = 5000;
+
+    // Mapping from hook entity id to allowed recipients set by account address
+    AssociatedLinkedListSet internal _allowedRecipients;
+
+    /**
+     * @dev Add allowed recipients/approved spenders.
+     * Can only be called by the current msg.sender.
+     */
+    function addAllowedRecipients(address[] calldata recipients) external {
+        _addRecipients(recipients);
+        emit AllowedAddressesAdded(msg.sender, recipients);
+    }
+
+    /**
+     * @dev Remove allowed recipients/approved spenders.
+     * Can only be called by the current msg.sender.
+     */
+    function removeAllowedRecipients(address[] calldata recipients) external {
+        uint256 length = recipients.length;
+        for (uint256 i = 0; i < length; ++i) {
+            if (!_allowedRecipients.tryRemove(msg.sender, CastLib.toSetValue(recipients[i]))) {
+                revert FailToRemoveRecipient(msg.sender, recipients[i]);
+            }
+        }
+        emit AllowedAddressesRemoved(msg.sender, recipients);
+    }
+
+    /**
+     * @dev Returns the allowed recipients/approved spenders of the current MSCA.
+     */
+    function getAllowedRecipients(address account) external view returns (address[] memory) {
+        return _getAllowedRecipients(account);
+    }
+
+    /// @inheritdoc IModule
+    function onInstall(bytes calldata data) external virtual override {
+        if (data.length != 0) {
+            address[] memory recipients = abi.decode(data, (address[]));
+            _addRecipients(recipients);
+            emit AllowedAddressesAdded(msg.sender, recipients);
+        }
+    }
+
+    /// @inheritdoc IModule
+    function onUninstall(bytes calldata data) external override {
+        (data);
+        address[] memory recipients = _getAllowedRecipients(msg.sender);
+        // Clearing up module storage is optional for the caller;
+        // callers should call removeAllowedRecipients in batches if they
+        // need to clear module storage.
+        if (recipients.length < _MAX_RECIPIENTS_TO_DELETE) {
+            _allowedRecipients.clear(msg.sender);
+            emit AllowedAddressesRemoved(msg.sender, recipients);
+        } else {
+            emit AllowedAddressesNotRemoved(msg.sender);
+        }
+    }
+
+    /// @inheritdoc IValidationHookModule
+    function preUserOpValidationHook(uint32, PackedUserOperation calldata userOp, bytes32)
+        external
+        view
+        override
+        assertNoData(userOp.signature)
+        returns (uint256 validationData)
+    {
+        // Extract selector used to execute uo on account and calldata from `userOp.callData`.
+        (bytes4 selector, bytes memory callDataWithoutSelector) =
+            _validationPhaseGetSelectorAndCalldata(userOp.callData);
+        verifyAllowedTargetOrRecipient(selector, callDataWithoutSelector);
+        return SIG_VALIDATION_SUCCEEDED;
+    }
+
+    /// @inheritdoc IValidationHookModule
+    function preRuntimeValidationHook(uint32, address, uint256, bytes calldata data, bytes calldata)
+        external
+        view
+        override
+    {
+        return verifyAllowedTargetOrRecipient(bytes4(data[:4]), data[4:]);
+    }
+
+    function preSignatureValidationHook(uint32 entityId, address sender, bytes32 hash, bytes calldata signature)
+        external
+        pure
+        override
+    {
+        (entityId, sender, hash, signature);
+        revert Unsupported();
+    }
+
+    function executionManifest() external pure override returns (ExecutionManifest memory) {
+        ExecutionManifest memory manifest;
+        manifest.executionFunctions = new ManifestExecutionFunction[](2);
+        // TODO: allow global validation
+        manifest.executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.addAllowedRecipients.selector,
+            skipRuntimeValidation: true,
+            allowGlobalValidation: false
+        });
+        manifest.executionFunctions[1] = ManifestExecutionFunction({
+            executionSelector: this.removeAllowedRecipients.selector,
+            skipRuntimeValidation: false,
+            allowGlobalValidation: true
+        });
+        manifest.interfaceIds = new bytes4[](1);
+        manifest.interfaceIds[0] = type(IAddressBookModule).interfaceId;
+        return manifest;
+    }
+
+    /// @inheritdoc IModule
+    function moduleId() external pure returns (string memory) {
+        return "avara.address-book-module.1.0.0";
+    }
+
+    /// @inheritdoc BaseModule
+    function supportsInterface(bytes4 interfaceId) public view override(BaseModule, IERC165) returns (bool) {
+        return interfaceId == type(IAddressBookModule).interfaceId
+            || interfaceId == type(IValidationHookModule).interfaceId || interfaceId == type(IExecutionModule).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+
+    /// @dev Verify if the target or recipient is allowed.
+    /// @dev Reverts if a native or token transfer recipient is found and the target/recipient is not allowed.
+    /// @param selector The selector used to execute the user operation or batch user operation.
+    /// @param callDataWithoutSelector The call data without the selector.
+    function verifyAllowedTargetOrRecipient(bytes4 selector, bytes memory callDataWithoutSelector) public view {
+        if (selector == IModularAccount.execute.selector) {
+            (address target, uint256 targetValue, bytes memory targetData) =
+                abi.decode(callDataWithoutSelector, (address, uint256, bytes));
+            _verifyAllowedTargetOrRecipient(target, targetValue, targetData);
+            return;
+        } else if (selector == IModularAccount.executeBatch.selector) {
+            Call[] memory calls = abi.decode(callDataWithoutSelector, (Call[]));
+            uint256 length = calls.length;
+            for (uint256 i = 0; i < length; ++i) {
+                _verifyAllowedTargetOrRecipient(calls[i].target, calls[i].value, calls[i].data);
+            }
+            return;
+        }
+        revert Unsupported();
+    }
+
+    function _verifyAllowedTargetOrRecipient(address target, uint256 value, bytes memory data) internal view {
+        if (
+            value == 0 && !data.containsERC20Methods() && !data.containsERC1155Methods()
+                && !data.containsERC721Methods()
+        ) {
+            // No transfer of assets, so no need to verify the recipient.
+            return;
+        }
+        // At this point we know that the calldata contains asset transfer logic.
+        address recipient = _getTargetOrRecipient(target, value, data);
+        if (!_allowedRecipients.contains(msg.sender, CastLib.toSetValue(recipient))) {
+            revert UnauthorizedRecipient(msg.sender, recipient);
+        }
+    }
+
+    /// @dev Add recipients.
+    /// @param recipientsToAdd The recipients to add.
+    function _addRecipients(address[] memory recipientsToAdd) internal {
+        uint256 length = recipientsToAdd.length;
+        for (uint256 i = 0; i < length; ++i) {
+            if (!_allowedRecipients.tryAdd(msg.sender, CastLib.toSetValue(recipientsToAdd[i]))) {
+                revert FailToAddRecipient(msg.sender, recipientsToAdd[i]);
+            }
+        }
+    }
+
+    /// @dev Get all allowed recipients for an account.
+    /// @param account The account.
+    /// @return The allowed recipients.
+    function _getAllowedRecipients(address account) internal view returns (address[] memory) {
+        return CastLib.toAddressArray(_allowedRecipients.getAll(account));
+    }
+
+    /// @dev We do not permit sending native assets to a token contract while simultaneously interacting with it.
+    /// @dev Get the recipient of the token transfer (ERC20, ERC1155, ERC721) or native asset transfer.
+    /// @dev Assumes the calldata contains asset transfer data.
+    /// @dev Reverts if any of the found token recipients are not in the account's address book or if the recipient is
+    /// address(0).
+    /// @param target The target address from a call parsed out of the execute/executeBatch function call.
+    /// @param value The native asset value from a call parsed out of the execute/executeBatch function call.
+    /// @param data The data from a call parsed out of the execute/executeBatch function call. If the target for this
+    /// call is a token contract.
+    /// @return The recipient of the token transfer or native asset transfer.
+    function _getTargetOrRecipient(address target, uint256 value, bytes memory data) internal view returns (address) {
+        if (value != 0) {
+            // For native asset transfers, we require the calldata to be empty.
+            if (data.length != 0) {
+                revert CallDataIsNotEmpty(msg.sender, target, value, data);
+            }
+            if (target == address(0)) {
+                // We do not allow sending native assets to address(0).
+                revert UnauthorizedRecipient(msg.sender, target);
+            }
+            return target;
+        } else {
+            // For token calls, we require that the target address contains code.
+            if (target.code.length == 0) {
+                revert InvalidTargetCodeLength(msg.sender, target, value, data);
+            }
+            // The helper function will first check if the function selector is supported.
+            address recipient = data.getERC20TokenRecipient();
+            if (recipient == address(0)) {
+                recipient = data.getERC1155TokenRecipient();
+            }
+            if (recipient == address(0)) {
+                recipient = data.getERC721TokenRecipient();
+            }
+            if (recipient == address(0)) {
+                revert UnauthorizedRecipient(msg.sender, recipient);
+            }
+            return recipient;
+        }
+    }
+}

--- a/test/msca/6900/v0.8/modules/AddressBookModule.t.sol
+++ b/test/msca/6900/v0.8/modules/AddressBookModule.t.sol
@@ -1,0 +1,1485 @@
+/*
+ * Copyright 2024 Circle Internet Group, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+pragma solidity 0.8.24;
+
+import {SIG_VALIDATION_SUCCEEDED} from "../../../../../src/common/Constants.sol";
+import {Unsupported} from "../../../../../src/common/Errors.sol";
+import {UnexpectedDataPassed} from "../../../../../src/msca/6900/shared/common/Errors.sol";
+
+import {Call} from "../../../../../src/msca/6900/v0.8/common/Structs.sol";
+import {AddressBookModule} from "../../../../../src/msca/6900/v0.8/modules/addressbook/AddressBookModule.sol";
+import {IAddressBookModule} from "../../../../../src/msca/6900/v0.8/modules/addressbook/IAddressBookModule.sol";
+
+import {TestERC1155} from "../../../../util/TestERC1155.sol";
+import {TestERC721} from "../../../../util/TestERC721.sol";
+import {TestLiquidityPool} from "../../../../util/TestLiquidityPool.sol";
+import {TestUtils} from "../../../../util/TestUtils.sol";
+
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+
+import {IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
+
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+contract AddressBookModuleTest is TestUtils {
+    AddressBookModule private addressBookModule;
+    TestERC1155 private testERC1155;
+    TestERC721 private testERC721;
+    TestLiquidityPool private testERC20;
+    TestLiquidityPool private testERC20_2;
+
+    address private account1;
+    address private account2;
+    address private recipient1;
+    address private recipient2;
+    address private recipient3;
+
+    // Events from IAddressBookModule
+    event AllowedAddressesAdded(address indexed account, address[] recipients);
+    event AllowedAddressesRemoved(address indexed account, address[] recipients);
+    event AllowedAddressesNotRemoved(address indexed account);
+
+    function setUp() public {
+        addressBookModule = new AddressBookModule();
+        testERC1155 = new TestERC1155("Test1155");
+        testERC721 = new TestERC721("Test721", "T721");
+        testERC20 = new TestLiquidityPool("TestERC20", "T20");
+        testERC20_2 = new TestLiquidityPool("TestERC20_2", "T20_2");
+
+        account1 = makeAddr("account1");
+        account2 = makeAddr("account2");
+        recipient1 = makeAddr("recipient1");
+        recipient2 = makeAddr("recipient2");
+        recipient3 = makeAddr("recipient3");
+
+        // Deploy some test token contracts
+        vm.deal(address(testERC20), 1 ether);
+        vm.deal(address(testERC721), 1 ether);
+        vm.deal(address(testERC1155), 1 ether);
+        vm.deal(recipient1, 1 ether);
+        vm.deal(recipient2, 1 ether);
+        vm.deal(recipient3, 1 ether);
+    }
+
+    // ==================== Basic Functionality Tests ====================
+
+    function test_addAllowedRecipients_Success() public {
+        address[] memory recipients = new address[](3);
+        recipients[0] = recipient1;
+        recipients[1] = recipient2;
+        recipients[2] = recipient3;
+
+        vm.prank(account1);
+        vm.expectEmit(true, false, false, true);
+        emit AllowedAddressesAdded(account1, recipients);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        address[] memory allowedRecipients = addressBookModule.getAllowedRecipients(account1);
+        assertEq(allowedRecipients.length, 3);
+        // the order of the recipients is in reverse (linked list set is ordered LIFO)
+        assertEq(allowedRecipients[2], recipient1);
+        assertEq(allowedRecipients[1], recipient2);
+        assertEq(allowedRecipients[0], recipient3);
+    }
+
+    function test_addZeroAddressRecipient() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = address(0);
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.FailToAddRecipient.selector, account1, address(0)));
+        addressBookModule.addAllowedRecipients(recipients);
+    }
+
+    function test_addAllowedRecipients_EmptyArray() public {
+        address[] memory recipients = new address[](0);
+
+        vm.prank(account1);
+        vm.expectEmit(true, false, false, true);
+        emit AllowedAddressesAdded(account1, recipients);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        address[] memory allowedRecipients = addressBookModule.getAllowedRecipients(account1);
+        assertEq(allowedRecipients.length, 0);
+    }
+
+    function test_addAllowedRecipients_DuplicateRecipient() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        // Add recipient first time
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Try to add same recipient again - should revert
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.FailToAddRecipient.selector, account1, recipient1));
+        addressBookModule.addAllowedRecipients(recipients);
+    }
+
+    function test_removeAllowedRecipients_Success() public {
+        // First add recipients
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1;
+        recipients[1] = recipient2;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Remove one recipient
+        address[] memory toRemove = new address[](1);
+        toRemove[0] = recipient1;
+
+        vm.prank(account1);
+        vm.expectEmit(true, false, false, true);
+        emit AllowedAddressesRemoved(account1, toRemove);
+        addressBookModule.removeAllowedRecipients(toRemove);
+
+        address[] memory allowedRecipients = addressBookModule.getAllowedRecipients(account1);
+        assertEq(allowedRecipients.length, 1);
+        assertEq(allowedRecipients[0], recipient2);
+    }
+
+    function test_removeAllowedRecipients_NonExistentRecipient() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.FailToRemoveRecipient.selector, account1, recipient1));
+        addressBookModule.removeAllowedRecipients(recipients);
+    }
+
+    function test_getAllowedRecipients_MultipleAccounts() public {
+        address[] memory recipients1 = new address[](1);
+        recipients1[0] = recipient1;
+
+        address[] memory recipients2 = new address[](1);
+        recipients2[0] = recipient2;
+
+        // Add recipients for account1
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients1);
+
+        // Add recipients for account2
+        vm.prank(account2);
+        addressBookModule.addAllowedRecipients(recipients2);
+
+        // Check each account has their own recipients
+        address[] memory account1Recipients = addressBookModule.getAllowedRecipients(account1);
+        address[] memory account2Recipients = addressBookModule.getAllowedRecipients(account2);
+
+        assertEq(account1Recipients.length, 1);
+        assertEq(account1Recipients[0], recipient1);
+
+        assertEq(account2Recipients.length, 1);
+        assertEq(account2Recipients[0], recipient2);
+    }
+
+    // ==================== Module Lifecycle Tests ====================
+
+    function test_onInstall_WithRecipients() public {
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1;
+        recipients[1] = recipient2;
+
+        bytes memory installData = abi.encode(recipients);
+
+        vm.prank(account1);
+        vm.expectEmit(true, false, false, true);
+        emit AllowedAddressesAdded(account1, recipients);
+        addressBookModule.onInstall(installData);
+
+        address[] memory allowedRecipients = addressBookModule.getAllowedRecipients(account1);
+        assertEq(allowedRecipients.length, 2);
+        // the order of the recipients is in reverse (linked list set is ordered LIFO)
+        assertEq(allowedRecipients[1], recipient1);
+        assertEq(allowedRecipients[0], recipient2);
+    }
+
+    function test_onInstall_WithoutRecipients() public {
+        bytes memory installData = "";
+
+        vm.prank(account1);
+        // Should not emit any events
+        addressBookModule.onInstall(installData);
+
+        address[] memory allowedRecipients = addressBookModule.getAllowedRecipients(account1);
+        assertEq(allowedRecipients.length, 0);
+    }
+
+    function test_onUninstall_FewRecipients() public {
+        // Add a few recipients (less than MAX_RECIPIENTS_TO_DELETE)
+        address[] memory recipients = new address[](3);
+        recipients[0] = recipient1;
+        recipients[1] = recipient2;
+        recipients[2] = recipient3;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Get the actual order that will be returned (LIFO order)
+        address[] memory actualOrder = addressBookModule.getAllowedRecipients(account1);
+
+        // Uninstall should clear all recipients
+        vm.prank(account1);
+        vm.expectEmit(true, false, false, true);
+        emit AllowedAddressesRemoved(account1, actualOrder);
+        addressBookModule.onUninstall("");
+
+        address[] memory allowedRecipients = addressBookModule.getAllowedRecipients(account1);
+        assertEq(allowedRecipients.length, 0);
+    }
+
+    // ==================== Token Validation Tests ====================
+
+    function test_verifyAllowedTargetOrRecipient_ERC20_Methods_Allowed() public {
+        // Add recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create ERC20 transfer calldata
+        bytes memory transferData = abi.encodeCall(IERC20.transfer, (recipient1, 100));
+        bytes memory executeTransferData = abi.encode(address(testERC20), 0, transferData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeTransferData);
+
+        // Create ERC20 transferFrom calldata
+        bytes memory transferFromData = abi.encodeCall(IERC20.transferFrom, (account1, recipient1, 100));
+        bytes memory executeTransferFromData = abi.encode(address(testERC20), 0, transferFromData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeTransferFromData);
+
+        // Create ERC20 approve calldata
+        bytes memory approveData = abi.encodeCall(IERC20.approve, (recipient1, 100));
+        bytes memory executeApproveData = abi.encode(address(testERC20), 0, approveData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeApproveData);
+
+        // Create ERC20 increaseAllowance calldata
+        bytes memory increaseAllowanceData =
+            abi.encodeWithSignature("increaseAllowance(address,uint256)", recipient1, 100);
+        bytes memory executeIncreaseAllowanceData = abi.encode(address(testERC20), 0, increaseAllowanceData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeIncreaseAllowanceData);
+
+        // Create ERC20 decreaseAllowance calldata
+        bytes memory decreaseAllowanceData =
+            abi.encodeWithSignature("decreaseAllowance(address,uint256)", recipient1, 100);
+        bytes memory executeDecreaseAllowanceData = abi.encode(address(testERC20), 0, decreaseAllowanceData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeDecreaseAllowanceData);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC20_Methods_Unauthorized() public {
+        // Don't add recipient to allowlist
+        bytes memory transferData = abi.encodeCall(IERC20.transfer, (recipient1, 100));
+        bytes memory executeTransferData = abi.encode(address(testERC20), 0, transferData);
+        // Should revert with UnauthorizedRecipient because no recipient is added to allowlist
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, recipient1));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeTransferData);
+
+        // Add recipient to allowlist and try again
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC20_Methods_Unchecked() public {
+        // Create ERC20 allowance calldata which would be considered to contain an erc20 method
+        bytes memory allowanceData = abi.encodeWithSignature("allowance(address,address)", account1, recipient1);
+        bytes memory executeAllowanceData = abi.encode(address(testERC20), 0, allowanceData);
+        vm.prank(account1);
+        // Should not revert
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeAllowanceData);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC721_Methods_Allowed() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create ERC721 transfer calldata
+        bytes memory transferData = abi.encodeCall(IERC721.transferFrom, (account1, recipient1, 1));
+        bytes memory executeTransferFromData = abi.encode(address(testERC721), 0, transferData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeTransferFromData);
+
+        // Create ERC721 safeTransferFrom  with bytes calldata
+        bytes memory safeTransferFromData =
+            abi.encodeWithSignature("safeTransferFrom(address,address,uint256,bytes)", account1, recipient1, 1, "");
+        bytes memory executeSafeTransferFromData = abi.encode(address(testERC721), 0, safeTransferFromData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeSafeTransferFromData);
+
+        // Create ERC721 approve calldata
+        bytes memory approveData = abi.encodeCall(IERC721.approve, (recipient1, 1));
+        bytes memory executeApproveData = abi.encode(address(testERC721), 0, approveData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeApproveData);
+
+        // Create ERC721 setApprovalForAll calldata
+        bytes memory setApprovalForAllData = abi.encodeCall(IERC721.setApprovalForAll, (recipient1, true));
+        bytes memory executeSetApprovalForAllData = abi.encode(address(testERC721), 0, setApprovalForAllData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeSetApprovalForAllData);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC1155_Methods_Allowed() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create ERC1155 transfer calldata
+        bytes memory transferData = abi.encodeCall(IERC1155.safeTransferFrom, (account1, recipient1, 1, 100, ""));
+        bytes memory executeSafeTransferFromData = abi.encode(address(testERC1155), 0, transferData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeSafeTransferFromData);
+
+        // Create ERC1155 safeBatchTransferFrom calldata
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
+        bytes memory safeBatchTransferFromData =
+            abi.encodeCall(IERC1155.safeBatchTransferFrom, (account1, recipient1, ids, amounts, ""));
+        bytes memory executeSafeBatchTransferFromData = abi.encode(address(testERC1155), 0, safeBatchTransferFromData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(
+            IModularAccount.execute.selector, executeSafeBatchTransferFromData
+        );
+
+        // Create ERC1155 setApprovalForAll calldata
+        bytes memory setApprovalForAllData = abi.encodeCall(IERC1155.setApprovalForAll, (recipient1, true));
+        bytes memory executeSetApprovalForAllData = abi.encode(address(testERC1155), 0, setApprovalForAllData);
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeSetApprovalForAllData);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_BatchExecute_Allowed() public {
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1;
+        recipients[1] = recipient2;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        Call[] memory calls = new Call[](2);
+        calls[0] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient1, 100))});
+        calls[1] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient2, 200))});
+
+        bytes memory batchCalldata = abi.encode(calls);
+
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_BatchExecute_OneUnauthorized() public {
+        // Add only one recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create batch calls with one unauthorized recipient
+        Call[] memory calls = new Call[](2);
+        calls[0] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient1, 100))});
+        calls[1] = Call({
+            target: address(testERC20),
+            value: 0,
+            data: abi.encodeCall(IERC20.transfer, (recipient2, 200)) // recipient2 not in allowlist
+        });
+
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for recipient2
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, recipient2));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    // ==================== Zero Address Recipient Tests ====================
+
+    function test_verifyAllowedTargetOrRecipient_ERC20Transfer_ZeroRecipient() public {
+        // Create ERC20 transfer calldata with zero address recipient
+        bytes memory transferData = abi.encodeCall(IERC20.transfer, (address(0), 100));
+        bytes memory executeCalldata = abi.encode(address(testERC20), 0, transferData);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC20Transfer_ZeroRecipient_Batch() public {
+        // Create ERC20 transfer calldata with zero address recipient
+        Call[] memory calls = new Call[](1);
+        calls[0] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (address(0), 100))});
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC20TransferFrom_ZeroRecipient() public {
+        // Create ERC20 transferFrom calldata with zero address recipient
+        bytes memory transferData = abi.encodeCall(IERC20.transferFrom, (account1, address(0), 100));
+        bytes memory executeCalldata = abi.encode(address(testERC20), 0, transferData);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC20TransferFrom_ZeroRecipient_Batch() public {
+        // Create ERC20 transferFrom calldata with zero address recipient
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            target: address(testERC20),
+            value: 0,
+            data: abi.encodeCall(IERC20.transferFrom, (account1, address(0), 100))
+        });
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC20Approve_ZeroRecipient() public {
+        // Create ERC20 approve calldata with zero address recipient (spender)
+        bytes memory approveData = abi.encodeCall(IERC20.approve, (address(0), 100));
+        bytes memory executeCalldata = abi.encode(address(testERC20), 0, approveData);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC20Approve_ZeroRecipient_Batch() public {
+        // Create ERC20 approve calldata with zero address recipient (spender)
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.approve, (address(0), 100))});
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC721Transfer_ZeroRecipient() public {
+        // Create ERC721 transfer calldata with zero address recipient
+        bytes memory transferData = abi.encodeCall(IERC721.transferFrom, (account1, address(0), 1));
+        bytes memory executeCalldata = abi.encode(address(testERC721), 0, transferData);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC721Transfer_ZeroRecipient_Batch() public {
+        // Create ERC721 transfer calldata with zero address recipient
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            target: address(testERC721),
+            value: 0,
+            data: abi.encodeCall(IERC721.transferFrom, (account1, address(0), 1))
+        });
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC721SafeTransferFrom_ZeroRecipient() public {
+        // Create ERC721 safeTransferFrom calldata with zero address recipient
+        bytes memory transferData =
+            abi.encodeWithSignature("safeTransferFrom(address,address,uint256)", account1, address(0), 1);
+        bytes memory executeCalldata = abi.encode(address(testERC721), 0, transferData);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC721SafeTransferFrom_ZeroRecipient_Batch() public {
+        // Create ERC721 safeTransferFrom calldata with zero address recipient
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            target: address(testERC721),
+            value: 0,
+            data: abi.encodeWithSignature("safeTransferFrom(address,address,uint256)", account1, address(0), 1)
+        });
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC721Approve_ZeroRecipient() public {
+        // Create ERC721 approve calldata with zero address recipient (spender)
+        bytes memory approveData = abi.encodeCall(IERC721.approve, (address(0), 1));
+        bytes memory executeCalldata = abi.encode(address(testERC721), 0, approveData);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC721Approve_ZeroRecipient_Batch() public {
+        // Create ERC721 approve calldata with zero address recipient (spender)
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({target: address(testERC721), value: 0, data: abi.encodeCall(IERC721.approve, (address(0), 1))});
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC721SetApprovalForAll_ZeroRecipient() public {
+        // Create ERC721 setApprovalForAll calldata with zero address recipient (operator)
+        bytes memory approveData = abi.encodeCall(IERC721.setApprovalForAll, (address(0), true));
+        bytes memory executeCalldata = abi.encode(address(testERC721), 0, approveData);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC721SetApprovalForAll_ZeroRecipient_Batch() public {
+        // Create ERC721 setApprovalForAll calldata with zero address recipient (operator)
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            target: address(testERC721),
+            value: 0,
+            data: abi.encodeCall(IERC721.setApprovalForAll, (address(0), true))
+        });
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC1155SafeTransferFrom_ZeroRecipient() public {
+        // Create ERC1155 safeTransferFrom calldata with zero address recipient
+        bytes memory transferData = abi.encodeCall(IERC1155.safeTransferFrom, (account1, address(0), 1, 100, ""));
+        bytes memory executeCalldata = abi.encode(address(testERC1155), 0, transferData);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC1155SafeTransferFrom_ZeroRecipient_Batch() public {
+        // Create ERC1155 safeTransferFrom calldata with zero address recipient
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            target: address(testERC1155),
+            value: 0,
+            data: abi.encodeCall(IERC1155.safeTransferFrom, (account1, address(0), 1, 100, ""))
+        });
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC1155SafeBatchTransferFrom_ZeroRecipient() public {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
+
+        // Create ERC1155 safeBatchTransferFrom calldata with zero address recipient
+        bytes memory transferData =
+            abi.encodeCall(IERC1155.safeBatchTransferFrom, (account1, address(0), ids, amounts, ""));
+        bytes memory executeCalldata = abi.encode(address(testERC1155), 0, transferData);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC1155SafeBatchTransferFrom_ZeroRecipient_Batch() public {
+        // Create ERC1155 safeBatchTransferFrom calldata with zero address recipient
+        Call[] memory calls = new Call[](1);
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
+        calls[0] = Call({
+            target: address(testERC1155),
+            value: 0,
+            data: abi.encodeCall(IERC1155.safeBatchTransferFrom, (account1, address(0), ids, amounts, ""))
+        });
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC1155SetApprovalForAll_ZeroRecipient() public {
+        // Create ERC1155 setApprovalForAll calldata with zero address recipient (operator)
+        bytes memory approveData = abi.encodeCall(IERC1155.setApprovalForAll, (address(0), true));
+        bytes memory executeCalldata = abi.encode(address(testERC1155), 0, approveData);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ERC1155SetApprovalForAll_ZeroRecipient_Batch() public {
+        // Create ERC1155 setApprovalForAll calldata with zero address recipient (operator)
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            target: address(testERC1155),
+            value: 0,
+            data: abi.encodeCall(IERC1155.setApprovalForAll, (address(0), true))
+        });
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    // ==================== Native Transfer Tests ====================
+
+    function test_verifyAllowedTargetOrRecipient_NativeTransfer_Allowed() public {
+        // Add recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create native transfer (value > 0, empty data)
+        bytes memory executeCalldata = abi.encode(recipient1, 1 ether, "");
+
+        // Should not revert
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_NativeTransfer_Unauthorized() public {
+        // Don't add recipient to allowlist
+
+        // Create native transfer (value > 0, empty data)
+        bytes memory executeCalldata = abi.encode(recipient1, 1 ether, "");
+
+        // Should revert with UnauthorizedRecipient
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, recipient1));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_NativeTransferToZeroAddress() public {
+        // Create native transfer to address(0)
+        bytes memory executeCalldata = abi.encode(address(0), 1 ether, "");
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_NativeTransferWithData() public {
+        // Add recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create native transfer with non-empty data (should fail)
+        bytes memory executeCalldata = abi.encode(recipient1, 1 ether, "0x1234");
+
+        // Should revert with CallDataIsNotEmpty
+        vm.prank(account1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAddressBookModule.CallDataIsNotEmpty.selector, account1, recipient1, 1 ether, "0x1234"
+            )
+        );
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    // ==================== Native Transfer Batch Tests ====================
+
+    function test_verifyAllowedTargetOrRecipient_NativeTransferBatch_Allowed() public {
+        // Add recipients to allowlist
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1;
+        recipients[1] = recipient2;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create batch native transfers (value > 0, empty data)
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({target: recipient1, value: 1 ether, data: ""});
+        calls[1] = Call({target: recipient2, value: 0.5 ether, data: ""});
+
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should not revert
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_NativeTransferBatch_Unauthorized() public {
+        // Add only one recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create batch native transfers with one unauthorized recipient
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({target: recipient1, value: 1 ether, data: ""});
+        calls[1] = Call({
+            target: recipient2, // Not in allowlist
+            value: 0.5 ether,
+            data: ""
+        });
+
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for recipient2
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, recipient2));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_NativeTransferBatchToZeroAddress() public {
+        // Add recipient1 to allowlist so the first call passes
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create batch native transfers with one to zero address
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({
+            target: recipient1, // This should pass
+            value: 1 ether,
+            data: ""
+        });
+        calls[1] = Call({
+            target: address(0), // Zero address - this should fail
+            value: 0.5 ether,
+            data: ""
+        });
+
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_NativeTransferBatchWithData() public {
+        // Add recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create batch native transfers with non-empty data (should fail)
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({target: recipient1, value: 1 ether, data: ""});
+        calls[1] = Call({
+            target: recipient1,
+            value: 0.5 ether,
+            data: "0x1234" // Non-empty data
+        });
+
+        bytes memory batchCalldata = abi.encode(calls);
+
+        // Should revert with CallDataIsNotEmpty for the second call
+        vm.prank(account1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAddressBookModule.CallDataIsNotEmpty.selector, account1, recipient1, 0.5 ether, "0x1234"
+            )
+        );
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.executeBatch.selector, batchCalldata);
+    }
+
+    // ==================== Validation Hook Tests ====================
+
+    function test_preUserOpValidationHook_Success() public {
+        // Add recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create user operation
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        // Empty signature required (empty signature is required for preUserOpValidationHook)
+        userOp.signature = "";
+
+        // Create ERC20 transfer calldata
+        bytes memory transferData = abi.encodeCall(IERC20.transfer, (recipient1, 100));
+        userOp.callData = abi.encodeCall(IModularAccount.execute, (address(testERC20), 0, transferData));
+
+        // Should return SIG_VALIDATION_SUCCEEDED
+        vm.prank(account1);
+        uint256 result = addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+        assertEq(result, SIG_VALIDATION_SUCCEEDED);
+    }
+
+    function test_preUserOpValidationHook_UnexpectedDataPassed() public {
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        // Non-empty signature should cause revert since hook runs in validation stage
+        userOp.signature = "0x1234";
+
+        // Should revert with UnexpectedDataPassed
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(UnexpectedDataPassed.selector));
+        addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+    }
+
+    // ==================== User Op Validation Hook Batch Tests ====================
+
+    function test_preUserOpValidationHook_ExecuteBatch_Success() public {
+        // Add recipients to allowlist
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1;
+        recipients[1] = recipient2;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create user operation with executeBatch
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        // Empty signature required (empty signature is required for preUserOpValidationHook)
+        userOp.signature = "";
+
+        // Create batch calls with token transfers
+        Call[] memory calls = new Call[](13);
+        calls[0] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient1, 100))});
+        calls[1] = Call({
+            target: address(testERC20),
+            value: 0,
+            data: abi.encodeCall(IERC20.transferFrom, (account1, recipient2, 200))
+        });
+        calls[2] = Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.approve, (recipient2, 300))});
+        bytes memory increaseAllowanceData =
+            abi.encodeWithSignature("increaseAllowance(address,uint256)", recipient1, 100);
+        calls[3] = Call({target: address(testERC20), value: 0, data: increaseAllowanceData});
+        bytes memory decreaseAllowanceData =
+            abi.encodeWithSignature("decreaseAllowance(address,uint256)", recipient1, 100);
+        calls[4] = Call({target: address(testERC20), value: 0, data: decreaseAllowanceData});
+        calls[5] = Call({
+            target: address(testERC721),
+            value: 0,
+            data: abi.encodeCall(IERC721.transferFrom, (account1, recipient2, 1))
+        });
+        bytes memory safeTransferFromData =
+            abi.encodeWithSignature("safeTransferFrom(address,address,uint256,bytes)", account1, recipient2, 1, "");
+        calls[6] = Call({target: address(testERC721), value: 0, data: safeTransferFromData});
+        bytes memory safeTransferFromWithBytesData =
+            abi.encodeWithSignature("safeTransferFrom(address,address,uint256,bytes)", account1, recipient2, 1, "");
+        calls[7] = Call({target: address(testERC721), value: 0, data: safeTransferFromWithBytesData});
+        calls[8] = Call({target: address(testERC721), value: 0, data: abi.encodeCall(IERC721.approve, (recipient2, 1))});
+        calls[9] = Call({
+            target: address(testERC721),
+            value: 0,
+            data: abi.encodeCall(IERC721.setApprovalForAll, (recipient2, true))
+        });
+        calls[10] = Call({
+            target: address(testERC1155),
+            value: 0,
+            data: abi.encodeCall(IERC1155.safeTransferFrom, (account1, recipient2, 1, 100, ""))
+        });
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
+        calls[11] = Call({
+            target: address(testERC1155),
+            value: 0,
+            data: abi.encodeCall(IERC1155.safeBatchTransferFrom, (account1, recipient2, ids, amounts, ""))
+        });
+        calls[12] = Call({
+            target: address(testERC1155),
+            value: 0,
+            data: abi.encodeCall(IERC1155.setApprovalForAll, (recipient2, true))
+        });
+
+        userOp.callData = abi.encodeWithSelector(IModularAccount.executeBatch.selector, calls);
+
+        // Should return SIG_VALIDATION_SUCCEEDED
+        vm.prank(account1);
+        uint256 result = addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+        assertEq(result, SIG_VALIDATION_SUCCEEDED);
+    }
+
+    function test_preUserOpValidationHook_ExecuteBatch_Success_TokenCall_OtherCalls() public {
+        // Add recipients to allowlist
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1;
+        recipients[1] = recipient2;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create user operation with executeBatch
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        userOp.signature = ""; // Empty signature required
+
+        // Create batch calls with token transfers and other calls
+        Call[] memory calls = new Call[](2);
+        calls[0] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient1, 100))});
+        bytes memory otherCallData = abi.encodeWithSignature("mint(address,uint256)", recipient2, 200);
+        calls[1] = Call({target: address(testERC20_2), value: 0, data: otherCallData});
+
+        userOp.callData = abi.encodeWithSelector(IModularAccount.executeBatch.selector, calls);
+
+        // Should return SIG_VALIDATION_SUCCEEDED
+        vm.prank(account1);
+        uint256 result = addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+        assertEq(result, SIG_VALIDATION_SUCCEEDED);
+    }
+
+    function test_preUserOpValidationHook_ExecuteBatch_UnauthorizedRecipient() public {
+        // Add only one recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create user operation with executeBatch
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        // Empty signature required (empty signature is required for preUserOpValidationHook)
+        userOp.signature = "";
+
+        // Create batch calls with one unauthorized recipient
+        Call[] memory calls = new Call[](2);
+        calls[0] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient1, 100))});
+        calls[1] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient2, 200))});
+
+        userOp.callData = abi.encodeWithSelector(IModularAccount.executeBatch.selector, calls);
+
+        // Should revert with UnauthorizedRecipient for recipient2
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, recipient2));
+        addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+    }
+
+    function test_preUserOpValidationHook_ExecuteBatch_NativeTransfers() public {
+        // Add recipients to allowlist
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1;
+        recipients[1] = recipient2;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create user operation with executeBatch for native transfers
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        // Empty signature required (empty signature is required for preUserOpValidationHook)
+        userOp.signature = "";
+
+        // Create batch calls with native transfers
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({target: recipient1, value: 1 ether, data: ""});
+        calls[1] = Call({target: recipient2, value: 0.5 ether, data: ""});
+
+        userOp.callData = abi.encodeWithSelector(IModularAccount.executeBatch.selector, calls);
+
+        // Should return SIG_VALIDATION_SUCCEEDED
+        vm.prank(account1);
+        uint256 result = addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+        assertEq(result, SIG_VALIDATION_SUCCEEDED);
+    }
+
+    function test_preUserOpValidationHook_ExecuteBatch_NativeTransferToZeroAddress() public {
+        // Add recipient1 to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create user operation with executeBatch
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        userOp.signature = ""; // Empty signature required
+
+        // Create batch calls with one transfer to zero address
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({target: recipient1, value: 1 ether, data: ""});
+        calls[1] = Call({target: address(0), value: 0.5 ether, data: ""});
+
+        userOp.callData = abi.encodeWithSelector(IModularAccount.executeBatch.selector, calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+    }
+
+    function test_preUserOpValidationHook_ExecuteBatch_MixedTokenAndNative() public {
+        // Add recipients to allowlist
+        address[] memory recipients = new address[](2);
+        recipients[0] = recipient1;
+        recipients[1] = recipient2;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create user operation with executeBatch
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        // Empty signature required (empty signature is required for preUserOpValidationHook)
+        userOp.signature = "";
+
+        // Create batch calls mixing token transfers and native transfers
+        Call[] memory calls = new Call[](3);
+        calls[0] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient1, 100))});
+        calls[1] = Call({target: recipient2, value: 1 ether, data: ""});
+        calls[2] = Call({
+            target: address(testERC1155),
+            value: 0,
+            data: abi.encodeCall(IERC1155.safeTransferFrom, (account1, recipient1, 1, 50, ""))
+        });
+
+        userOp.callData = abi.encodeWithSelector(IModularAccount.executeBatch.selector, calls);
+
+        // Should return SIG_VALIDATION_SUCCEEDED
+        vm.prank(account1);
+        uint256 result = addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+        assertEq(result, SIG_VALIDATION_SUCCEEDED);
+    }
+
+    function test_preUserOpValidationHook_ExecuteBatch_NonTokenMethod() public {
+        // Add recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create user operation with executeBatch
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        // Empty signature required (empty signature is required for preUserOpValidationHook)
+        userOp.signature = "";
+
+        // Create batch calls with non-token methods (should pass through)
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({
+            target: address(testERC20),
+            value: 0,
+            data: abi.encodeCall(testERC20.mint, (recipient1, 100)) // Non-tracked method
+        });
+        calls[1] = Call({
+            target: address(testERC20),
+            value: 0,
+            data: abi.encodeCall(IERC20.transfer, (recipient1, 50)) // Tracked method
+        });
+
+        userOp.callData = abi.encodeWithSelector(IModularAccount.executeBatch.selector, calls);
+
+        // Should return SIG_VALIDATION_SUCCEEDED (mint is ignored, transfer is validated)
+        vm.prank(account1);
+        uint256 result = addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+        assertEq(result, SIG_VALIDATION_SUCCEEDED);
+    }
+
+    function test_preUserOpValidationHook_ExecuteBatch_EmptyBatch() public {
+        // Create user operation with empty executeBatch
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        // Empty signature required (empty signature is required for preUserOpValidationHook)
+        userOp.signature = "";
+
+        // Create empty batch
+        Call[] memory calls = new Call[](0);
+        userOp.callData = abi.encodeWithSelector(IModularAccount.executeBatch.selector, calls);
+
+        // Should return SIG_VALIDATION_SUCCEEDED (no calls to validate)
+        vm.prank(account1);
+        uint256 result = addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+        assertEq(result, SIG_VALIDATION_SUCCEEDED);
+    }
+
+    function test_preUserOpValidationHook_ExecuteBatch_TokenTransferZeroRecipient() public {
+        // Add recipient1 to allowlist so the first call passes
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create user operation with executeBatch
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        // Empty signature required (empty signature is required for preUserOpValidationHook)
+        userOp.signature = "";
+
+        // Create batch calls with token transfer to zero address
+        Call[] memory calls = new Call[](2);
+        calls[0] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient1, 100))});
+        calls[1] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (address(0), 200))});
+
+        userOp.callData = abi.encodeWithSelector(IModularAccount.executeBatch.selector, calls);
+
+        // Should revert with UnauthorizedRecipient for address(0)
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+    }
+
+    function test_preUserOpValidationHook_ExecuteBatch_MultipleTokenTypesZeroRecipient() public {
+        // Add recipient1 to allowlist so valid calls pass
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create user operation with executeBatch
+        PackedUserOperation memory userOp;
+        userOp.sender = account1;
+        // Empty signature required (empty signature is required for preUserOpValidationHook)
+        userOp.signature = "";
+
+        // Create batch calls with different token types, one with zero recipient
+        Call[] memory calls = new Call[](3);
+        calls[0] =
+            Call({target: address(testERC20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient1, 100))});
+        calls[1] = Call({
+            target: address(testERC721),
+            value: 0,
+            data: abi.encodeCall(IERC721.transferFrom, (account1, recipient1, 1))
+        });
+        calls[2] = Call({
+            target: address(testERC1155),
+            value: 0,
+            data: abi.encodeCall(IERC1155.safeTransferFrom, (account1, address(0), 1, 50, ""))
+        });
+
+        userOp.callData = abi.encodeWithSelector(IModularAccount.executeBatch.selector, calls);
+
+        // Should revert with UnauthorizedRecipient for address(0) in the ERC1155 transfer
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(IAddressBookModule.UnauthorizedRecipient.selector, account1, address(0)));
+        addressBookModule.preUserOpValidationHook(0, userOp, bytes32(0));
+    }
+
+    function test_preRuntimeValidationHook_Success() public {
+        // Add recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create ERC20 transfer calldata
+        bytes memory transferData = abi.encodeCall(IERC20.transfer, (recipient1, 100));
+        bytes memory fullCalldata = abi.encodeCall(IModularAccount.execute, (address(testERC20), 0, transferData));
+
+        // Should not revert
+        vm.prank(account1);
+        addressBookModule.preRuntimeValidationHook(0, account1, 0, fullCalldata, "");
+    }
+
+    function test_preSignatureValidationHook_Unsupported() public {
+        // Should always revert with Unsupported
+        vm.expectRevert(abi.encodeWithSelector(Unsupported.selector));
+        addressBookModule.preSignatureValidationHook(0, account1, bytes32(0), "");
+    }
+
+    // ==================== Error Conditions Tests ====================
+
+    function test_verifyAllowedTargetOrRecipient_UnsupportedSelector() public {
+        bytes memory executeCalldata = abi.encode(address(testERC20), 0, "");
+
+        // Should revert with Unsupported for unknown selector
+        vm.prank(account1);
+        vm.expectRevert(abi.encodeWithSelector(Unsupported.selector));
+        addressBookModule.verifyAllowedTargetOrRecipient(bytes4(0x12345678), executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_TokenContractWithoutCode() public {
+        // Create a non-contract address
+        address nonContract = makeAddr("nonContract");
+
+        // Create ERC20 transfer calldata targeting non-contract
+        bytes memory transferData = abi.encodeCall(IERC20.transfer, (recipient1, 100));
+        bytes memory executeCalldata = abi.encode(nonContract, 0, transferData);
+
+        // Should revert with InvalidTargetCodeLength
+        vm.prank(account1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAddressBookModule.InvalidTargetCodeLength.selector, account1, nonContract, 0, transferData
+            )
+        );
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_NonTokenMethod() public {
+        // Add recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create calldata for non-token method (e.g., mint)
+        bytes memory mintData = abi.encodeCall(testERC20.mint, (recipient1, 100));
+        bytes memory executeCalldata = abi.encode(address(testERC20), 0, mintData);
+
+        // Should not revert because mint is not a tracked token method
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    // ==================== Module Metadata Tests ====================
+
+    function test_moduleId() public view {
+        string memory moduleId = addressBookModule.moduleId();
+        assertEq(moduleId, "avara.address-book-module.1.0.0");
+    }
+
+    function test_supportsInterface() public view {
+        assertTrue(addressBookModule.supportsInterface(type(IAddressBookModule).interfaceId));
+        assertTrue(addressBookModule.supportsInterface(type(IModule).interfaceId));
+        assertTrue(addressBookModule.supportsInterface(type(IValidationHookModule).interfaceId));
+        assertTrue(addressBookModule.supportsInterface(type(IExecutionModule).interfaceId));
+        assertFalse(addressBookModule.supportsInterface(bytes4(0x12345678)));
+    }
+
+    function test_executionManifest() public view {
+        ExecutionManifest memory manifest = addressBookModule.executionManifest();
+
+        // Should have 2 execution functions
+        assertEq(manifest.executionFunctions.length, 2);
+
+        // Check addAllowedRecipients function
+        assertEq(manifest.executionFunctions[0].executionSelector, addressBookModule.addAllowedRecipients.selector);
+        assertTrue(manifest.executionFunctions[0].skipRuntimeValidation);
+        assertFalse(manifest.executionFunctions[0].allowGlobalValidation);
+
+        // Check removeAllowedRecipients function
+        assertEq(manifest.executionFunctions[1].executionSelector, addressBookModule.removeAllowedRecipients.selector);
+        assertFalse(manifest.executionFunctions[1].skipRuntimeValidation);
+        assertTrue(manifest.executionFunctions[1].allowGlobalValidation);
+
+        // Should have 1 interface ID
+        assertEq(manifest.interfaceIds.length, 1);
+        assertEq(manifest.interfaceIds[0], type(IAddressBookModule).interfaceId);
+    }
+
+    // ==================== Edge Cases and Malformed Data Tests ====================
+
+    function test_verifyAllowedTargetOrRecipient_MalformedERC20Transfer() public {
+        // Create malformed ERC20 transfer calldata (too short)
+        bytes memory malformedData = abi.encodePacked(IERC20.transfer.selector, uint128(0x1234));
+        bytes memory executeCalldata = abi.encode(address(testERC20), 0, malformedData);
+
+        // Should not revert because malformed data fails the length check in containsERC20Methods()
+        // So the module treats it as a non-token method and skips validation.
+        // Calls containing insufficient calldata for parameter decoding will revert.
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_MalformedERC20Transfer_DirectCall() public {
+        // This test demonstrates what happens if malformed calldata actually reaches the ERC20 contract
+
+        // Try to call the ERC20 contract directly with malformed data
+        // This should revert because Solidity cannot decode the parameters properly
+        assertGt(address(testERC20).code.length, 0, "no code at address");
+        // Mint some tokens so the transfer can succeed
+        testERC20.mint(address(this), 1000);
+        bytes memory transferData = abi.encodeWithSelector(IERC20.transfer.selector, address(1), uint256(1));
+        (bool transferSuccess,) = address(testERC20).call(transferData);
+        assertTrue(transferSuccess);
+
+        // Try to call the ERC20 contract with malformed data (too short)
+        bytes memory malformedData = abi.encodePacked(IERC20.transfer.selector, uint128(0x1234));
+        (bool success,) = address(testERC20).call(malformedData);
+
+        // The call should fail due to insufficient calldata for parameter decoding
+        assertFalse(success);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ExtraLongERC20Transfer_DirectCall() public {
+        // This test shows what happens with extra-long calldata (more than needed)
+
+        // Create ERC20 transfer calldata with extra bytes at the end
+        bytes memory normalTransferData = abi.encodeCall(IERC20.transfer, (recipient1, 100));
+        bytes memory extraLongData = abi.encodePacked(normalTransferData, "extra_garbage_data_here");
+
+        // Mint some tokens first so the transfer can succeed
+        testERC20.mint(address(this), 1000);
+
+        // Try to call the ERC20 contract with extra-long calldata
+        // This should SUCCEED - Solidity ignores extra bytes at the end
+        (bool success,) = address(testERC20).call(extraLongData);
+
+        // The call should succeed because Solidity only reads what it needs
+        assertTrue(success);
+
+        // Verify the transfer actually worked
+        assertEq(testERC20.balanceOf(recipient1), 100);
+    }
+
+    function test_verifyAllowedTargetOrRecipient_ZeroValueTokenCall() public {
+        // Add recipient to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient1;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create ERC20 transfer with zero value (should still work)
+        bytes memory transferData = abi.encodeCall(IERC20.transfer, (recipient1, 0));
+        bytes memory executeCalldata = abi.encode(address(testERC20), 0, transferData);
+
+        // Should not revert
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+
+    function test_fuzz_addAllowedRecipients(address[] memory recipients) public {
+        vm.assume(recipients.length > 0 && recipients.length < 100);
+
+        // Filter out zero addresses and duplicates
+        address[] memory filteredRecipients = new address[](recipients.length);
+        uint256 count = 0;
+
+        for (uint256 i = 0; i < recipients.length; i++) {
+            if (recipients[i] != address(0)) {
+                bool isDuplicate = false;
+                for (uint256 j = 0; j < count; j++) {
+                    if (filteredRecipients[j] == recipients[i]) {
+                        isDuplicate = true;
+                        break;
+                    }
+                }
+                if (!isDuplicate) {
+                    filteredRecipients[count] = recipients[i];
+                    count++;
+                }
+            }
+        }
+
+        if (count == 0) return;
+
+        // Resize array
+        assembly {
+            mstore(filteredRecipients, count)
+        }
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(filteredRecipients);
+
+        address[] memory allowedRecipients = addressBookModule.getAllowedRecipients(account1);
+        assertEq(allowedRecipients.length, count);
+    }
+
+    function test_fuzz_verifyAllowedTargetOrRecipient_NativeTransfer(address target, uint256 value) public {
+        vm.assume(target != address(0));
+        vm.assume(value > 0);
+
+        // Add target to allowlist
+        address[] memory recipients = new address[](1);
+        recipients[0] = target;
+
+        vm.prank(account1);
+        addressBookModule.addAllowedRecipients(recipients);
+
+        // Create native transfer
+        bytes memory executeCalldata = abi.encode(target, value, "");
+
+        // Should not revert
+        vm.prank(account1);
+        addressBookModule.verifyAllowedTargetOrRecipient(IModularAccount.execute.selector, executeCalldata);
+    }
+}


### PR DESCRIPTION
## Summary
- The existing 6900 v0.8 module `ColdStorageAddressBookModule.sol` requires that an account only executes calls to transfer assets. If a call does not have selector that matches the checked token (ERC-20, ERC-721, ERC-1155) selectors the function `_getTargetOrRecipient()` returns `address(0)` and therefore execution reverts.
- Motivation for this module is to allow an account to make calls that are not intended to transfer assets (native or token) while asserting calls that do transfer assets (based on the selectors this module will check) transfer to white listed recipients or approve whitelisted spenders.
- This hook module can be installed alongside another hook that enforces which targets and selectors can be called.
- Implements `IValidationHookModule`, `IExecutionModule`.

## Detail
### Changeset
The module being added in this change will first check if any of the checked selectors is found in any of the execution's calls - if not then the hook allows execution to proceed (assumes no assets are being transferred by the calls in the execution).

### Checklist
- [x] Did you add new tests and confirm all tests pass? (`yarn test`)
- [x] Did you ensure any new Solidity source code files meet minimum test coverage requirements? (`yarn coverage`)
- [ ] Did you update relevant docs? (docs are found in the `docs` folder)
- [x] Do your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Does your PR title also follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard?
- [x] Did you run lint (`yarn lint`) and fix any issues?
- [x] Did you run formatter (`yarn format:check`) and fix any issues (`yarn format:write`)?

## Testing
See `AddressBookModule.t.sol`.
