### PR TITLE
fix(ColdStorageAddressBookModule): enforce validation on addAllowedRecipients and unblock module execution calls

### DIFF
--- a/src/msca/6900/v0.8/modules/addressbook/ColdStorageAddressBookModule.sol
+++ b/src/msca/6900/v0.8/modules/addressbook/ColdStorageAddressBookModule.sol
@@ -184,7 +184,9 @@ contract ColdStorageAddressBookModule is IAddressBookModule, BaseModule {
             }
             return SIG_VALIDATION_SUCCEEDED;
         }
-        revert Unsupported();
+        // Allow calls to unknown entity IDs (e.g. module execution functions
+        // like addAllowedRecipients) to pass through without blocking.
+        return SIG_VALIDATION_SUCCEEDED;
     }
 
     /// @inheritdoc IValidationHookModule
@@ -217,7 +219,9 @@ contract ColdStorageAddressBookModule is IAddressBookModule, BaseModule {
             }
             return;
         }
-        revert Unsupported();
+        // Allow calls to unknown entity IDs (e.g. module execution functions
+        // like addAllowedRecipients) to pass through without blocking.
+        return;
     }
 
     function preSignatureValidationHook(uint32 entityId, address sender, bytes32 hash, bytes calldata signature)
@@ -235,8 +239,8 @@ contract ColdStorageAddressBookModule is IAddressBookModule, BaseModule {
         // TODO: allow global validation
         manifest.executionFunctions[0] = ManifestExecutionFunction({
             executionSelector: this.addAllowedRecipients.selector,
-            skipRuntimeValidation: true,
-            allowGlobalValidation: false
+            skipRuntimeValidation: false,
+            allowGlobalValidation: true
         });
         manifest.executionFunctions[1] = ManifestExecutionFunction({
             executionSelector: this.removeAllowedRecipients.selector,


### PR DESCRIPTION
Fixes #111 and #112.

## Problem

**Issue #111 - Unauthorized allowlist expansion:**
\ddAllowedRecipients()\ was configured with \skipRuntimeValidation: true\ in the execution manifest, allowing any external address to call \ccount.addAllowedRecipients([attackerAddress])\ without authorization. Meanwhile, \emoveAllowedRecipients()\ correctly used \skipRuntimeValidation: false\.

**Issue #112 - Validation hook blocks module execution functions:**
\preUserOpValidationHook\ and \preRuntimeValidationHook\ reverted with \Unsupported()\ for unrecognized entity IDs. When the module's validation hook is installed and a call to \ddAllowedRecipients()\ or \emoveAllowedRecipients()\ is made directly (not via \execute()\/\executeBatch()\), the hook doesn't recognize the entity ID and reverts, blocking the intended execution flow.

## Fix

1. Changed \skipRuntimeValidation: true\ to \alse\ for \ddAllowedRecipients\ - runtime validation is now enforced
2. Set \llowGlobalValidation: true\ for \ddAllowedRecipients\ to match \emoveAllowedRecipients\
3. Replaced \evert Unsupported()\ with passthrough \eturn\ in both \preUserOpValidationHook\ and \preRuntimeValidationHook\ for unrecognized entity IDs

Single file, +8/-4 lines.